### PR TITLE
refactor: improved and generalized API plus a variety of fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ testcover: testci
 #
 #     AUTOBAHN_CASES=5.7,6.12.* make testautobahn
 testautobahn:
-	AUTOBAHN_TESTS=1 AUTOBAHN_OPEN_REPORT=1 go test -v -run ^TestWebSocketServer$$ $(TEST_ARGS) ./...
+	AUTOBAHN_TESTS=1 AUTOBAHN_OPEN_REPORT=1 go test -run ^TestWebSocketServer$$ $(TEST_ARGS) ./...
 .PHONY: autobahntests
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Default flags used by the test, testci, testcover targets
 COVERAGE_PATH ?= coverage.out
 COVERAGE_ARGS ?= -covermode=atomic -coverprofile=$(COVERAGE_PATH)
-TEST_ARGS     ?= -race $(COVERAGE_ARGS)
+TEST_ARGS     ?= -race -timeout 90s
 
 # 3rd party tools
 LINT        := go run github.com/mgechev/revive@v1.5.1

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,12 @@ testcover: testci
 	go tool cover -html=$(COVERAGE_PATH)
 .PHONY: testcover
 
-# Run the autobahn fuzzingclient test suite
+# Run the autobahn fuzzingclient test suite (requires docker running locally).
+#
+# To run only a subset of autobahn tests, specify them in an AUTOBAHN_CASES env
+# var:
+#
+#     AUTOBAHN_CASES=5.7,6.12.* make testautobahn
 testautobahn:
 	AUTOBAHN_TESTS=1 AUTOBAHN_OPEN_REPORT=1 go test -v -run ^TestWebSocketServer$$ $(TEST_ARGS) ./...
 .PHONY: autobahntests

--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,7 @@ import (
 
 func ExampleEchoHandler() {
 	http.ListenAndServe(":8080", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ws, err := websocket.Accept(w, r, websocket.Limits{
+		ws, err := websocket.Accept(w, r, websocket.Options{
 			MaxDuration:     10 * time.Second,
 			MaxFragmentSize: 10 * 1024,
 			MaxMessageSize:  512 * 1024,

--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,7 @@
 package websocket_test
 
 import (
+	"log"
 	"net/http"
 	"time"
 
@@ -8,7 +9,7 @@ import (
 )
 
 func ExampleEchoHandler() {
-	http.ListenAndServe(":8080", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ws, err := websocket.Accept(w, r, websocket.Options{
 			ReadTimeout:     500 * time.Millisecond,
 			WriteTimeout:    500 * time.Millisecond,
@@ -20,5 +21,8 @@ func ExampleEchoHandler() {
 			return
 		}
 		ws.Serve(r.Context(), websocket.EchoHandler)
-	}))
+	})
+	if err := http.ListenAndServe(":8080", handler); err != nil {
+		log.Fatalf("error starting server: %v", err)
+	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -8,18 +8,16 @@ import (
 )
 
 func ExampleEchoHandler() {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
-		ws := websocket.New(w, r, websocket.Limits{
+	http.ListenAndServe(":8080", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, websocket.Limits{
 			MaxDuration:     10 * time.Second,
 			MaxFragmentSize: 10 * 1024,
 			MaxMessageSize:  512 * 1024,
 		})
-		if err := ws.Handshake(); err != nil {
+		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		ws.Serve(websocket.EchoHandler)
-	})
-	http.ListenAndServe(":8080", mux)
+		ws.Serve(r.Context(), websocket.EchoHandler)
+	}))
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,25 @@
+package websocket_test
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/mccutchen/websocket"
+)
+
+func ExampleEchoHandler() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
+		ws := websocket.New(w, r, websocket.Limits{
+			MaxDuration:     10 * time.Second,
+			MaxFragmentSize: 10 * 1024,
+			MaxMessageSize:  512 * 1024,
+		})
+		if err := ws.Handshake(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		ws.Serve(websocket.EchoHandler)
+	})
+	http.ListenAndServe(":8080", mux)
+}

--- a/example_test.go
+++ b/example_test.go
@@ -10,7 +10,8 @@ import (
 func ExampleEchoHandler() {
 	http.ListenAndServe(":8080", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ws, err := websocket.Accept(w, r, websocket.Options{
-			MaxDuration:     10 * time.Second,
+			ReadTimeout:     500 * time.Millisecond,
+			WriteTimeout:    500 * time.Millisecond,
 			MaxFragmentSize: 10 * 1024,
 			MaxMessageSize:  512 * 1024,
 		})

--- a/internal/testing/assert/assert.go
+++ b/internal/testing/assert/assert.go
@@ -40,7 +40,7 @@ func DeepEqual[T any](t *testing.T, got, want T, msg string, arg ...any) {
 func NilError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {
-		t.Fatalf("expected nil error, got %s (%T)", err, err)
+		t.Fatalf("expected nil error, got %q (%T)", err, err)
 	}
 }
 
@@ -53,7 +53,7 @@ func Error(t *testing.T, got, expected error) {
 				return
 			}
 		}
-		t.Fatalf("expected error %v, got %v", expected, got)
+		t.Fatalf("expected error %q, got %v", expected, got)
 	}
 }
 

--- a/proto.go
+++ b/proto.go
@@ -20,6 +20,9 @@ var (
 	ErrUnmaskedClientFrame  = errors.New("received unmasked client frame")
 )
 
+// ClientKey is a websocket client key.
+type ClientKey string
+
 // Opcode is a websocket OPCODE.
 type Opcode uint8
 

--- a/proto.go
+++ b/proto.go
@@ -1,0 +1,305 @@
+package websocket
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"unicode/utf8"
+)
+
+const requiredVersion = "13"
+
+// Opcode is a websocket OPCODE.
+type Opcode uint8
+
+// See the RFC for the set of defined opcodes:
+// https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
+const (
+	OpcodeContinuation Opcode = 0x0
+	OpcodeText         Opcode = 0x1
+	OpcodeBinary       Opcode = 0x2
+	OpcodeClose        Opcode = 0x8
+	OpcodePing         Opcode = 0x9
+	OpcodePong         Opcode = 0xA
+)
+
+// StatusCode is a websocket status code.
+type StatusCode uint16
+
+// See the RFC for the set of defined status codes:
+// https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
+const (
+	StatusNormalClosure      StatusCode = 1000
+	StatusGoingAway          StatusCode = 1001
+	StatusProtocolError      StatusCode = 1002
+	StatusUnsupported        StatusCode = 1003
+	StatusNoStatusRcvd       StatusCode = 1005
+	StatusAbnormalClose      StatusCode = 1006
+	StatusUnsupportedPayload StatusCode = 1007
+	StatusPolicyViolation    StatusCode = 1008
+	StatusTooLarge           StatusCode = 1009
+	StatusTlSHandshake       StatusCode = 1015
+	StatusServerError        StatusCode = 1011
+)
+
+// Frame is a websocket protocol frame.
+type Frame struct {
+	Fin     bool
+	RSV1    bool
+	RSV3    bool
+	RSV2    bool
+	Opcode  Opcode
+	Payload []byte
+}
+
+// Message is an application-level message from the client, which may be
+// constructed from one or more individual protocol frames.
+type Message struct {
+	Binary  bool
+	Payload []byte
+}
+
+func nextFrame(buf io.Reader) (*Frame, error) {
+	bb := make([]byte, 2)
+	if _, err := io.ReadFull(buf, bb); err != nil {
+		return nil, err
+	}
+
+	b0 := bb[0]
+	b1 := bb[1]
+
+	var (
+		fin    = b0&0b10000000 != 0
+		rsv1   = b0&0b01000000 != 0
+		rsv2   = b0&0b00100000 != 0
+		rsv3   = b0&0b00010000 != 0
+		opcode = Opcode(b0 & 0b00001111)
+	)
+
+	// Per https://datatracker.ietf.org/doc/html/rfc6455#section-5.2, all
+	// client frames must be masked.
+	if masked := b1 & 0b10000000; masked == 0 {
+		return nil, fmt.Errorf("received unmasked client frame")
+	}
+
+	var payloadLength uint64
+	switch {
+	case b1-128 <= 125:
+		// Payload length is directly represented in the second byte
+		payloadLength = uint64(b1 - 128)
+	case b1-128 == 126:
+		// Payload length is represented in the next 2 bytes (16-bit unsigned integer)
+		var l uint16
+		if err := binary.Read(buf, binary.BigEndian, &l); err != nil {
+			return nil, err
+		}
+		payloadLength = uint64(l)
+	case b1-128 == 127:
+		// Payload length is represented in the next 8 bytes (64-bit unsigned integer)
+		if err := binary.Read(buf, binary.BigEndian, &payloadLength); err != nil {
+			return nil, err
+		}
+	}
+
+	mask := make([]byte, 4)
+	if _, err := io.ReadFull(buf, mask); err != nil {
+		return nil, err
+	}
+
+	payload := make([]byte, payloadLength)
+	if _, err := io.ReadFull(buf, payload); err != nil {
+		return nil, err
+	}
+
+	for i, b := range payload {
+		payload[i] = b ^ mask[i%4]
+	}
+
+	return &Frame{
+		Fin:     fin,
+		RSV1:    rsv1,
+		RSV2:    rsv2,
+		RSV3:    rsv3,
+		Opcode:  opcode,
+		Payload: payload,
+	}, nil
+}
+
+func writeFrame(dst *bufio.ReadWriter, frame *Frame) error {
+	// FIN, RSV1-3, OPCODE
+	var b1 byte
+	if frame.Fin {
+		b1 |= 0b10000000
+	}
+	if frame.RSV1 {
+		b1 |= 0b01000000
+	}
+	if frame.RSV2 {
+		b1 |= 0b00100000
+	}
+	if frame.RSV3 {
+		b1 |= 0b00010000
+	}
+	b1 |= uint8(frame.Opcode) & 0b00001111
+	if err := dst.WriteByte(b1); err != nil {
+		return err
+	}
+
+	// payload length
+	payloadLen := int64(len(frame.Payload))
+	switch {
+	case payloadLen <= 125:
+		if err := dst.WriteByte(byte(payloadLen)); err != nil {
+			return err
+		}
+	case payloadLen <= 65535:
+		if err := dst.WriteByte(126); err != nil {
+			return err
+		}
+		if err := binary.Write(dst, binary.BigEndian, uint16(payloadLen)); err != nil {
+			return err
+		}
+	default:
+		if err := dst.WriteByte(127); err != nil {
+			return err
+		}
+		if err := binary.Write(dst, binary.BigEndian, payloadLen); err != nil {
+			return err
+		}
+	}
+
+	// payload
+	if _, err := dst.Write(frame.Payload); err != nil {
+		return err
+	}
+
+	return dst.Flush()
+}
+
+// writeCloseFrame writes a close frame to the wire, with an optional error
+// message.
+func writeCloseFrame(dst *bufio.ReadWriter, code StatusCode, err error) error {
+	var payload []byte
+	payload = binary.BigEndian.AppendUint16(payload, uint16(code))
+	if err != nil {
+		payload = append(payload, []byte(err.Error())...)
+	}
+	return writeFrame(dst, &Frame{
+		Fin:     true,
+		Opcode:  OpcodeClose,
+		Payload: payload,
+	})
+}
+
+// frameResponse splits a message into N frames with payloads of at most
+// fragmentSize bytes.
+func frameResponse(msg *Message, fragmentSize int) []*Frame {
+	var result []*Frame
+
+	fin := false
+	opcode := OpcodeText
+	if msg.Binary {
+		opcode = OpcodeBinary
+	}
+
+	offset := 0
+	dataLen := len(msg.Payload)
+	for {
+		if offset > 0 {
+			opcode = OpcodeContinuation
+		}
+		end := offset + fragmentSize
+		if end >= dataLen {
+			fin = true
+			end = dataLen
+		}
+		result = append(result, &Frame{
+			Fin:     fin,
+			Opcode:  opcode,
+			Payload: msg.Payload[offset:end],
+		})
+		if fin {
+			break
+		}
+	}
+	return result
+}
+
+var reservedStatusCodes = map[uint16]bool{
+	// Explicitly reserved by RFC section 7.4.1 Defined Status Codes:
+	// https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
+	1004: true,
+	1005: true,
+	1006: true,
+	1015: true,
+	// Apparently reserved, according to the autobahn testsuite's fuzzingclient
+	// tests, though it's not clear to me why, based on the RFC.
+	//
+	// See: https://github.com/crossbario/autobahn-testsuite
+	1016: true,
+	1100: true,
+	2000: true,
+	2999: true,
+}
+
+func validateFrame(frame *Frame, maxFragmentSize int) error {
+	// We do not support any extensions, per the spec all RSV bits must be 0:
+	// https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
+	if frame.RSV1 || frame.RSV2 || frame.RSV3 {
+		return fmt.Errorf("frame has unsupported RSV bits set")
+	}
+
+	switch frame.Opcode {
+	case OpcodeContinuation, OpcodeText, OpcodeBinary:
+		if len(frame.Payload) > maxFragmentSize {
+			return fmt.Errorf("frame payload size %d exceeds maximum of %d bytes", len(frame.Payload), maxFragmentSize)
+		}
+	case OpcodeClose, OpcodePing, OpcodePong:
+		// All control frames MUST have a payload length of 125 bytes or less
+		// and MUST NOT be fragmented.
+		// https://datatracker.ietf.org/doc/html/rfc6455#section-5.5
+		if len(frame.Payload) > 125 {
+			return fmt.Errorf("frame payload size %d exceeds 125 bytes", len(frame.Payload))
+		}
+		if !frame.Fin {
+			return fmt.Errorf("control frame %v must not be fragmented", frame.Opcode)
+		}
+	}
+
+	if frame.Opcode == OpcodeClose {
+		if len(frame.Payload) == 0 {
+			return nil
+		}
+		if len(frame.Payload) == 1 {
+			return fmt.Errorf("close frame payload must be at least 2 bytes")
+		}
+
+		code := binary.BigEndian.Uint16(frame.Payload[:2])
+		if code < 1000 || code >= 5000 {
+			return fmt.Errorf("close frame status code %d out of range", code)
+		}
+		if reservedStatusCodes[code] {
+			return fmt.Errorf("close frame status code %d is reserved", code)
+		}
+
+		if len(frame.Payload) > 2 {
+			if !utf8.Valid(frame.Payload[2:]) {
+				return errors.New("close frame payload must be vaid UTF-8")
+			}
+		}
+	}
+
+	return nil
+}
+
+func acceptKey(clientKey string) string {
+	// Magic value comes from RFC 6455 section 1.3: Opening Handshake
+	// https://www.rfc-editor.org/rfc/rfc6455#section-1.3
+	h := sha1.New()
+	_, _ = io.WriteString(h, clientKey+"258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}

--- a/proto.go
+++ b/proto.go
@@ -160,21 +160,21 @@ func WriteFrame(dst io.Writer, frame *Frame) error {
 	buf := make([]byte, 0, 13+len(frame.Payload))
 
 	// FIN, RSV1-3, OPCODE
-	var b1 byte
+	var b0 byte
 	if frame.Fin {
-		b1 |= 0b10000000
+		b0 |= 0b10000000
 	}
 	if frame.RSV1 {
-		b1 |= 0b01000000
+		b0 |= 0b01000000
 	}
 	if frame.RSV2 {
-		b1 |= 0b00100000
+		b0 |= 0b00100000
 	}
 	if frame.RSV3 {
-		b1 |= 0b00010000
+		b0 |= 0b00010000
 	}
-	b1 |= uint8(frame.Opcode) & 0b00001111
-	buf = append(buf, b1)
+	b0 |= uint8(frame.Opcode) & 0b00001111
+	buf = append(buf, b0)
 
 	// payload length
 	payloadLen := int64(len(frame.Payload))

--- a/proto.go
+++ b/proto.go
@@ -13,6 +13,12 @@ import (
 
 const requiredVersion = "13"
 
+var (
+	ErrContinuationExpected = errors.New("expected continuation frame")
+	ErrInvalidContinuation  = errors.New("unexpected continuation frame")
+	ErrInvalidUT8           = errors.New("invalid UTF-8")
+)
+
 // Opcode is a websocket OPCODE.
 type Opcode uint8
 
@@ -61,6 +67,14 @@ type Frame struct {
 type Message struct {
 	Binary  bool
 	Payload []byte
+}
+
+func (m Message) String() string {
+	if m.Binary {
+		return fmt.Sprintf("Message{Binary: %v, Payload: %v}", m.Binary, m.Payload)
+	} else {
+		return fmt.Sprintf("Message{Binary: %v, Payload: %q}", m.Binary, m.Payload)
+	}
 }
 
 func nextFrame(buf io.Reader) (*Frame, error) {

--- a/proto.go
+++ b/proto.go
@@ -81,7 +81,8 @@ func (m Message) String() string {
 	}
 }
 
-func readFrame(buf io.Reader) (*Frame, error) {
+// ReadFrame reads a websocket frame from the wire.
+func ReadFrame(buf io.Reader) (*Frame, error) {
 	bb := make([]byte, 2)
 	if _, err := io.ReadFull(buf, bb); err != nil {
 		return nil, fmt.Errorf("error reading frame header: %w", err)
@@ -147,7 +148,8 @@ func readFrame(buf io.Reader) (*Frame, error) {
 	}, nil
 }
 
-func writeFrame(dst *bufio.ReadWriter, frame *Frame) error {
+// WriteFrame writes a websocket frame to the wire.
+func WriteFrame(dst *bufio.ReadWriter, frame *Frame) error {
 	// FIN, RSV1-3, OPCODE
 	var b1 byte
 	if frame.Fin {
@@ -206,7 +208,7 @@ func writeCloseFrame(dst *bufio.ReadWriter, code StatusCode, err error) error {
 	if err != nil {
 		payload = append(payload, []byte(err.Error())...)
 	}
-	return writeFrame(dst, &Frame{
+	return WriteFrame(dst, &Frame{
 		Fin:     true,
 		Opcode:  OpcodeClose,
 		Payload: payload,

--- a/websocket.go
+++ b/websocket.go
@@ -155,11 +155,13 @@ func (s *WebSocket) Serve(handler Handler) {
 
 	// best effort attempt to ensure that our websocket conenctions do not
 	// exceed the maximum request duration
-	if err := conn.SetDeadline(time.Now().Add(s.maxDuration)); err != nil {
-		panic(fmt.Errorf("websocket: serve: failed to set deadline on connection: %s", err))
+	if s.maxDuration > 0 {
+		if err := conn.SetDeadline(time.Now().Add(s.maxDuration)); err != nil {
+			panic(fmt.Errorf("websocket: serve: failed to set deadline on connection: %s", err))
+		}
 	}
 
-	// errors intentionally ignored here. it's serverLoop's responsibility to
+	// errors intentionally ignored here. it's serveLoop's responsibility to
 	// properly close the websocket connection with a useful error message, and
 	// any unexpected error returned from serverLoop is not actionable.
 	_ = s.serveLoop(s.r.Context(), buf, handler)

--- a/websocket.go
+++ b/websocket.go
@@ -203,7 +203,7 @@ func (c *Conn) Read(ctx context.Context) (*Message, error) {
 			return nil, io.EOF
 		case OpcodePing:
 			frame.Opcode = OpcodePong
-			if err := WriteFrame(c.buf, frame); err != nil {
+			if err := WriteFrame(c.conn, frame); err != nil {
 				return nil, err
 			}
 			continue
@@ -232,7 +232,7 @@ func (c *Conn) Write(ctx context.Context, msg *Message) error {
 		default:
 			c.resetWriteDeadline()
 		}
-		if err := WriteFrame(c.buf, frame); err != nil {
+		if err := WriteFrame(c.conn, frame); err != nil {
 			return c.closeOnWriteError(StatusServerError, err)
 		}
 	}
@@ -269,7 +269,7 @@ func (c *Conn) Close() error {
 func (c *Conn) closeWithError(code StatusCode, err error) error {
 	c.hooks.OnClose(c.clientKey, code, err)
 	close(c.closedCh)
-	_ = writeCloseFrame(c.buf, code, err)
+	_ = writeCloseFrame(c.conn, code, err)
 	return c.conn.Close()
 }
 

--- a/websocket.go
+++ b/websocket.go
@@ -4,12 +4,10 @@ package websocket
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -169,11 +167,6 @@ func (c *Conn) Read(ctx context.Context) (*Message, error) {
 			code := StatusServerError
 			if err == io.EOF {
 				code = StatusNormalClosure
-			} else if isTimeoutError(err) {
-				// autobahn tests 6.4.1 and 6.4.2 expect a close frame with no
-				// status code on a read timeout. seems wrong to me, but
-				// currently needed to pass the autobahn test suite.
-				code = StatusNoStatus
 			}
 			return nil, c.closeOnReadError(code, err)
 		}
@@ -305,8 +298,4 @@ func (c *Conn) resetWriteDeadline() {
 	if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeTimeout)); err != nil {
 		panic(fmt.Sprintf("websocket: failed to set write deadline: %s", err))
 	}
-}
-
-func isTimeoutError(err error) bool {
-	return errors.Is(err, os.ErrDeadlineExceeded)
 }

--- a/websocket.go
+++ b/websocket.go
@@ -4,10 +4,12 @@ package websocket
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -167,6 +169,11 @@ func (c *Conn) Read(ctx context.Context) (*Message, error) {
 			code := StatusServerError
 			if err == io.EOF {
 				code = StatusNormalClosure
+			} else if isTimeoutError(err) {
+				// autobahn tests 6.4.1 and 6.4.2 expect a close frame with no
+				// status code on a read timeout. seems wrong to me, but
+				// currently needed to pass the autobahn test suite.
+				code = StatusNoStatus
 			}
 			return nil, c.closeOnReadError(code, err)
 		}
@@ -298,4 +305,8 @@ func (c *Conn) resetWriteDeadline() {
 	if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeTimeout)); err != nil {
 		panic(fmt.Sprintf("websocket: failed to set write deadline: %s", err))
 	}
+}
+
+func isTimeoutError(err error) bool {
+	return errors.Is(err, os.ErrDeadlineExceeded)
 }

--- a/websocket.go
+++ b/websocket.go
@@ -241,7 +241,7 @@ func (s *WebSocket) serveLoop(ctx context.Context, buf *bufio.ReadWriter, handle
 	}
 }
 
-func nextFrame(buf *bufio.ReadWriter) (*Frame, error) {
+func nextFrame(buf io.Reader) (*Frame, error) {
 	bb := make([]byte, 2)
 	if _, err := io.ReadFull(buf, bb); err != nil {
 		return nil, err

--- a/websocket.go
+++ b/websocket.go
@@ -4,69 +4,15 @@ package websocket
 import (
 	"bufio"
 	"context"
-	"crypto/sha1"
-	"encoding/base64"
-	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
+	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 )
-
-const requiredVersion = "13"
-
-// Opcode is a websocket OPCODE.
-type Opcode uint8
-
-// See the RFC for the set of defined opcodes:
-// https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
-const (
-	OpcodeContinuation Opcode = 0x0
-	OpcodeText         Opcode = 0x1
-	OpcodeBinary       Opcode = 0x2
-	OpcodeClose        Opcode = 0x8
-	OpcodePing         Opcode = 0x9
-	OpcodePong         Opcode = 0xA
-)
-
-// StatusCode is a websocket status code.
-type StatusCode uint16
-
-// See the RFC for the set of defined status codes:
-// https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
-const (
-	StatusNormalClosure      StatusCode = 1000
-	StatusGoingAway          StatusCode = 1001
-	StatusProtocolError      StatusCode = 1002
-	StatusUnsupported        StatusCode = 1003
-	StatusNoStatusRcvd       StatusCode = 1005
-	StatusAbnormalClose      StatusCode = 1006
-	StatusUnsupportedPayload StatusCode = 1007
-	StatusPolicyViolation    StatusCode = 1008
-	StatusTooLarge           StatusCode = 1009
-	StatusTlSHandshake       StatusCode = 1015
-	StatusServerError        StatusCode = 1011
-)
-
-// Frame is a websocket protocol frame.
-type Frame struct {
-	Fin     bool
-	RSV1    bool
-	RSV3    bool
-	RSV2    bool
-	Opcode  Opcode
-	Payload []byte
-}
-
-// Message is an application-level message from the client, which may be
-// constructed from one or more individual protocol frames.
-type Message struct {
-	Binary  bool
-	Payload []byte
-}
 
 // Handler handles a single websocket message. If the returned message is
 // non-nil, it will be sent to the client. If an error is returned, the
@@ -86,398 +32,186 @@ type Limits struct {
 	MaxMessageSize  int
 }
 
-// WebSocket is a websocket connection.
-type WebSocket struct {
-	w               http.ResponseWriter
-	r               *http.Request
+// Conn is a websocket connection.
+type Conn struct {
+	conn   net.Conn
+	buf    *bufio.ReadWriter
+	closed *atomic.Bool
+
 	maxDuration     time.Duration
 	maxFragmentSize int
 	maxMessageSize  int
-	handshook       bool
 }
 
-// New creates a new websocket.
-func New(w http.ResponseWriter, r *http.Request, limits Limits) *WebSocket {
-	return &WebSocket{
-		w:               w,
-		r:               r,
-		maxDuration:     limits.MaxDuration,
-		maxFragmentSize: limits.MaxFragmentSize,
-		maxMessageSize:  limits.MaxMessageSize,
-	}
-}
-
-// Handshake validates the request and performs the WebSocket handshake. If
-// Handshake returns nil, only websocket frames should be written to the
-// response writer.
-func (s *WebSocket) Handshake() error {
-	if s.handshook {
-		panic("websocket: handshake already completed")
+// Accept upgrades an HTTP connection to a websocket connection.
+func Accept(w http.ResponseWriter, r *http.Request, limits Limits) (*Conn, error) {
+	if err := handshake(w, r); err != nil {
+		return nil, fmt.Errorf("websocket: accept: handshake failed: %w", err)
 	}
 
-	if strings.ToLower(s.r.Header.Get("Upgrade")) != "websocket" {
-		return fmt.Errorf("missing required `Upgrade: websocket` header")
-	}
-	if v := s.r.Header.Get("Sec-Websocket-Version"); v != requiredVersion {
-		return fmt.Errorf("only websocket version %q is supported, got %q", requiredVersion, v)
-	}
-
-	clientKey := s.r.Header.Get("Sec-Websocket-Key")
-	if clientKey == "" {
-		return fmt.Errorf("missing required `Sec-Websocket-Key` header")
-	}
-
-	s.w.Header().Set("Connection", "upgrade")
-	s.w.Header().Set("Upgrade", "websocket")
-	s.w.Header().Set("Sec-Websocket-Accept", acceptKey(clientKey))
-	s.w.WriteHeader(http.StatusSwitchingProtocols)
-
-	s.handshook = true
-	return nil
-}
-
-// Serve handles a websocket connection after the handshake has been completed.
-func (s *WebSocket) Serve(handler Handler) {
-	if !s.handshook {
-		panic("websocket: serve: handshake not completed")
-	}
-
-	hj, ok := s.w.(http.Hijacker)
+	hj, ok := w.(http.Hijacker)
 	if !ok {
-		panic("websocket: serve: server does not support hijacking")
+		panic("websocket: accept: server does not support hijacking")
 	}
 
 	conn, buf, err := hj.Hijack()
 	if err != nil {
-		panic(fmt.Errorf("websocket: serve: hijack failed: %s", err))
+		panic(fmt.Errorf("websocket: accept: hijack failed: %s", err))
 	}
-	defer conn.Close()
 
 	// best effort attempt to ensure that our websocket conenctions do not
 	// exceed the maximum request duration
-	if s.maxDuration > 0 {
-		if err := conn.SetDeadline(time.Now().Add(s.maxDuration)); err != nil {
+	if limits.MaxDuration > 0 {
+		if err := conn.SetDeadline(time.Now().Add(limits.MaxDuration)); err != nil {
 			panic(fmt.Errorf("websocket: serve: failed to set deadline on connection: %s", err))
 		}
 	}
 
-	// errors intentionally ignored here. it's serveLoop's responsibility to
-	// properly close the websocket connection with a useful error message, and
-	// any unexpected error returned from serverLoop is not actionable.
-	_ = s.serveLoop(s.r.Context(), buf, handler)
+	return &Conn{
+		conn:            conn,
+		buf:             buf,
+		closed:          &atomic.Bool{},
+		maxDuration:     limits.MaxDuration,
+		maxFragmentSize: limits.MaxFragmentSize,
+		maxMessageSize:  limits.MaxMessageSize,
+	}, nil
 }
 
-func (s *WebSocket) serveLoop(ctx context.Context, buf *bufio.ReadWriter, handler Handler) error {
-	var currentMsg *Message
+// handshake validates the request and performs the WebSocket handshake, after
+// which only websocket frames should be written to the underlying connection.
+func handshake(w http.ResponseWriter, r *http.Request) error {
+	if strings.ToLower(r.Header.Get("Upgrade")) != "websocket" {
+		return fmt.Errorf("missing required `Upgrade: websocket` header")
+	}
+	if v := r.Header.Get("Sec-Websocket-Version"); v != requiredVersion {
+		return fmt.Errorf("only websocket version %q is supported, got %q", requiredVersion, v)
+	}
 
+	clientKey := r.Header.Get("Sec-Websocket-Key")
+	if clientKey == "" {
+		return fmt.Errorf("missing required `Sec-Websocket-Key` header")
+	}
+
+	w.Header().Set("Connection", "upgrade")
+	w.Header().Set("Upgrade", "websocket")
+	w.Header().Set("Sec-Websocket-Accept", acceptKey(clientKey))
+	w.WriteHeader(http.StatusSwitchingProtocols)
+	return nil
+}
+
+// Read reads a single websocket message from the connection. Ping/pong frames
+// are handled automatically. The connection will be closed on any error.
+func (c *Conn) Read(ctx context.Context) (*Message, error) {
+	var msg *Message
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return nil, ctx.Err()
 		default:
+			if c.closed.Load() {
+				panic("websocket: read: connection already closed")
+			}
 		}
 
-		frame, err := nextFrame(buf)
+		frame, err := nextFrame(c.buf)
 		if err != nil {
-			return writeCloseFrame(buf, StatusServerError, err)
+			return nil, c.closeWithError(StatusServerError, err)
 		}
 
-		if err := validateFrame(frame, s.maxFragmentSize); err != nil {
-			return writeCloseFrame(buf, StatusProtocolError, err)
+		if err := validateFrame(frame, c.maxFragmentSize); err != nil {
+			return nil, c.closeWithError(StatusProtocolError, err)
 		}
 
 		switch frame.Opcode {
 		case OpcodeBinary, OpcodeText:
-			if currentMsg != nil {
-				return writeCloseFrame(buf, StatusProtocolError, errors.New("expected continuation frame"))
+			if msg != nil {
+				return nil, c.closeWithError(StatusProtocolError, errors.New("expected continuation frame"))
 			}
 			if frame.Opcode == OpcodeText && !utf8.Valid(frame.Payload) {
-				return writeCloseFrame(buf, StatusUnsupportedPayload, errors.New("invalid UTF-8"))
+				return nil, c.closeWithError(StatusUnsupportedPayload, errors.New("invalid UTF-8"))
 			}
-			currentMsg = &Message{
+			msg = &Message{
 				Binary:  frame.Opcode == OpcodeBinary,
 				Payload: frame.Payload,
 			}
 		case OpcodeContinuation:
-			if currentMsg == nil {
-				return writeCloseFrame(buf, StatusProtocolError, errors.New("unexpected continuation frame"))
+			if msg == nil {
+				return nil, c.closeWithError(StatusProtocolError, errors.New("unexpected continuation frame"))
 			}
-			if !currentMsg.Binary && !utf8.Valid(frame.Payload) {
-				return writeCloseFrame(buf, StatusUnsupportedPayload, errors.New("invalid UTF-8"))
+			if !msg.Binary && !utf8.Valid(frame.Payload) {
+				return nil, c.closeWithError(StatusUnsupportedPayload, errors.New("invalid UTF-8"))
 			}
-			currentMsg.Payload = append(currentMsg.Payload, frame.Payload...)
-			if len(currentMsg.Payload) > s.maxMessageSize {
-				return writeCloseFrame(buf, StatusTooLarge, fmt.Errorf("message size %d exceeds maximum of %d bytes", len(currentMsg.Payload), s.maxMessageSize))
+			msg.Payload = append(msg.Payload, frame.Payload...)
+			if len(msg.Payload) > c.maxMessageSize {
+				return nil, c.closeWithError(StatusTooLarge, fmt.Errorf("message size %d exceeds maximum of %d bytes", len(msg.Payload), c.maxMessageSize))
 			}
 		case OpcodeClose:
-			return writeCloseFrame(buf, StatusNormalClosure, nil)
+			return nil, c.closeWithError(StatusNormalClosure, nil)
 		case OpcodePing:
 			frame.Opcode = OpcodePong
-			if err := writeFrame(buf, frame); err != nil {
-				return err
+			if err := writeFrame(c.buf, frame); err != nil {
+				return nil, err
 			}
-			continue
 		case OpcodePong:
-			continue
+			// no-op
 		default:
-			return writeCloseFrame(buf, StatusProtocolError, fmt.Errorf("unsupported opcode: %v", frame.Opcode))
+			return nil, c.closeWithError(StatusProtocolError, fmt.Errorf("unsupported opcode: %v", frame.Opcode))
 		}
 
 		if frame.Fin {
-			resp, err := handler(ctx, currentMsg)
-			if err != nil {
-				return writeCloseFrame(buf, StatusServerError, err)
-			}
-			if resp == nil {
-				continue
-			}
-			for _, respFrame := range frameResponse(resp, s.maxFragmentSize) {
-				if err := writeFrame(buf, respFrame); err != nil {
-					return err
-				}
-			}
-			currentMsg = nil
+			return msg, nil
 		}
 	}
 }
 
-func nextFrame(buf io.Reader) (*Frame, error) {
-	bb := make([]byte, 2)
-	if _, err := io.ReadFull(buf, bb); err != nil {
-		return nil, err
-	}
-
-	b0 := bb[0]
-	b1 := bb[1]
-
-	var (
-		fin    = b0&0b10000000 != 0
-		rsv1   = b0&0b01000000 != 0
-		rsv2   = b0&0b00100000 != 0
-		rsv3   = b0&0b00010000 != 0
-		opcode = Opcode(b0 & 0b00001111)
-	)
-
-	// Per https://datatracker.ietf.org/doc/html/rfc6455#section-5.2, all
-	// client frames must be masked.
-	if masked := b1 & 0b10000000; masked == 0 {
-		return nil, fmt.Errorf("received unmasked client frame")
-	}
-
-	var payloadLength uint64
-	switch {
-	case b1-128 <= 125:
-		// Payload length is directly represented in the second byte
-		payloadLength = uint64(b1 - 128)
-	case b1-128 == 126:
-		// Payload length is represented in the next 2 bytes (16-bit unsigned integer)
-		var l uint16
-		if err := binary.Read(buf, binary.BigEndian, &l); err != nil {
-			return nil, err
-		}
-		payloadLength = uint64(l)
-	case b1-128 == 127:
-		// Payload length is represented in the next 8 bytes (64-bit unsigned integer)
-		if err := binary.Read(buf, binary.BigEndian, &payloadLength); err != nil {
-			return nil, err
-		}
-	}
-
-	mask := make([]byte, 4)
-	if _, err := io.ReadFull(buf, mask); err != nil {
-		return nil, err
-	}
-
-	payload := make([]byte, payloadLength)
-	if _, err := io.ReadFull(buf, payload); err != nil {
-		return nil, err
-	}
-
-	for i, b := range payload {
-		payload[i] = b ^ mask[i%4]
-	}
-
-	return &Frame{
-		Fin:     fin,
-		RSV1:    rsv1,
-		RSV2:    rsv2,
-		RSV3:    rsv3,
-		Opcode:  opcode,
-		Payload: payload,
-	}, nil
-}
-
-func writeFrame(dst *bufio.ReadWriter, frame *Frame) error {
-	// FIN, RSV1-3, OPCODE
-	var b1 byte
-	if frame.Fin {
-		b1 |= 0b10000000
-	}
-	if frame.RSV1 {
-		b1 |= 0b01000000
-	}
-	if frame.RSV2 {
-		b1 |= 0b00100000
-	}
-	if frame.RSV3 {
-		b1 |= 0b00010000
-	}
-	b1 |= uint8(frame.Opcode) & 0b00001111
-	if err := dst.WriteByte(b1); err != nil {
-		return err
-	}
-
-	// payload length
-	payloadLen := int64(len(frame.Payload))
-	switch {
-	case payloadLen <= 125:
-		if err := dst.WriteByte(byte(payloadLen)); err != nil {
-			return err
-		}
-	case payloadLen <= 65535:
-		if err := dst.WriteByte(126); err != nil {
-			return err
-		}
-		if err := binary.Write(dst, binary.BigEndian, uint16(payloadLen)); err != nil {
-			return err
-		}
-	default:
-		if err := dst.WriteByte(127); err != nil {
-			return err
-		}
-		if err := binary.Write(dst, binary.BigEndian, payloadLen); err != nil {
-			return err
-		}
-	}
-
-	// payload
-	if _, err := dst.Write(frame.Payload); err != nil {
-		return err
-	}
-
-	return dst.Flush()
-}
-
-// writeCloseFrame writes a close frame to the wire, with an optional error
-// message.
-func writeCloseFrame(dst *bufio.ReadWriter, code StatusCode, err error) error {
-	var payload []byte
-	payload = binary.BigEndian.AppendUint16(payload, uint16(code))
-	if err != nil {
-		payload = append(payload, []byte(err.Error())...)
-	}
-	return writeFrame(dst, &Frame{
-		Fin:     true,
-		Opcode:  OpcodeClose,
-		Payload: payload,
-	})
-}
-
-// frameResponse splits a message into N frames with payloads of at most
-// fragmentSize bytes.
-func frameResponse(msg *Message, fragmentSize int) []*Frame {
-	var result []*Frame
-
-	fin := false
-	opcode := OpcodeText
-	if msg.Binary {
-		opcode = OpcodeBinary
-	}
-
-	offset := 0
-	dataLen := len(msg.Payload)
-	for {
-		if offset > 0 {
-			opcode = OpcodeContinuation
-		}
-		end := offset + fragmentSize
-		if end >= dataLen {
-			fin = true
-			end = dataLen
-		}
-		result = append(result, &Frame{
-			Fin:     fin,
-			Opcode:  opcode,
-			Payload: msg.Payload[offset:end],
-		})
-		if fin {
-			break
-		}
-	}
-	return result
-}
-
-var reservedStatusCodes = map[uint16]bool{
-	// Explicitly reserved by RFC section 7.4.1 Defined Status Codes:
-	// https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
-	1004: true,
-	1005: true,
-	1006: true,
-	1015: true,
-	// Apparently reserved, according to the autobahn testsuite's fuzzingclient
-	// tests, though it's not clear to me why, based on the RFC.
-	//
-	// See: https://github.com/crossbario/autobahn-testsuite
-	1016: true,
-	1100: true,
-	2000: true,
-	2999: true,
-}
-
-func validateFrame(frame *Frame, maxFragmentSize int) error {
-	// We do not support any extensions, per the spec all RSV bits must be 0:
-	// https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
-	if frame.RSV1 || frame.RSV2 || frame.RSV3 {
-		return fmt.Errorf("frame has unsupported RSV bits set")
-	}
-
-	switch frame.Opcode {
-	case OpcodeContinuation, OpcodeText, OpcodeBinary:
-		if len(frame.Payload) > maxFragmentSize {
-			return fmt.Errorf("frame payload size %d exceeds maximum of %d bytes", len(frame.Payload), maxFragmentSize)
-		}
-	case OpcodeClose, OpcodePing, OpcodePong:
-		// All control frames MUST have a payload length of 125 bytes or less
-		// and MUST NOT be fragmented.
-		// https://datatracker.ietf.org/doc/html/rfc6455#section-5.5
-		if len(frame.Payload) > 125 {
-			return fmt.Errorf("frame payload size %d exceeds 125 bytes", len(frame.Payload))
-		}
-		if !frame.Fin {
-			return fmt.Errorf("control frame %v must not be fragmented", frame.Opcode)
-		}
-	}
-
-	if frame.Opcode == OpcodeClose {
-		if len(frame.Payload) == 0 {
-			return nil
-		}
-		if len(frame.Payload) == 1 {
-			return fmt.Errorf("close frame payload must be at least 2 bytes")
-		}
-
-		code := binary.BigEndian.Uint16(frame.Payload[:2])
-		if code < 1000 || code >= 5000 {
-			return fmt.Errorf("close frame status code %d out of range", code)
-		}
-		if reservedStatusCodes[code] {
-			return fmt.Errorf("close frame status code %d is reserved", code)
-		}
-
-		if len(frame.Payload) > 2 {
-			if !utf8.Valid(frame.Payload[2:]) {
-				return errors.New("close frame payload must be vaid UTF-8")
+func (c *Conn) Write(ctx context.Context, msg *Message) error {
+	frames := frameResponse(msg, c.maxFragmentSize)
+	for _, frame := range frames {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if c.closed.Load() {
+				panic("websocket: write: connection already closed")
 			}
 		}
+		if err := writeFrame(c.buf, frame); err != nil {
+			return err
+		}
 	}
-
 	return nil
 }
 
-func acceptKey(clientKey string) string {
-	// Magic value comes from RFC 6455 section 1.3: Opening Handshake
-	// https://www.rfc-editor.org/rfc/rfc6455#section-1.3
-	h := sha1.New()
-	_, _ = io.WriteString(h, clientKey+"258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
-	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+func (c *Conn) Serve(ctx context.Context, handler Handler) {
+	for {
+		msg, err := c.Read(ctx)
+		if err != nil {
+			// an error in Read() closes the connection
+			return
+		}
+
+		resp, err := handler(ctx, msg)
+		if err != nil {
+			_ = c.closeWithError(StatusServerError, err)
+			return
+		}
+
+		if resp != nil {
+			if err := c.Write(ctx, resp); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (c *Conn) Close() error {
+	return c.closeWithError(StatusNormalClosure, nil)
+}
+
+func (c *Conn) closeWithError(code StatusCode, err error) error {
+	if c.closed.Swap(true) {
+		panic("websocket: close: connection already closed")
+	}
+	_ = writeCloseFrame(c.buf, code, err)
+	return c.conn.Close()
 }

--- a/websocket_autobahn_test.go
+++ b/websocket_autobahn_test.go
@@ -191,7 +191,8 @@ func loadSummary(t *testing.T, testDir string) autobahnReportSummary {
 func loadReport(t *testing.T, testDir string, reportFile string) autobahnReportResult {
 	t.Helper()
 	reportPath := path.Join(testDir, "report", reportFile)
-	t.Logf("report path: %s", reportPath)
+	t.Logf("report data: %s", reportPath)
+	t.Logf("report html: file://%s", strings.Replace(reportPath, ".json", ".html", 1))
 	f, err := os.Open(reportPath)
 	assert.NilError(t, err)
 	var report autobahnReportResult

--- a/websocket_autobahn_test.go
+++ b/websocket_autobahn_test.go
@@ -60,7 +60,7 @@ func TestWebSocketServer(t *testing.T) {
 			Hooks: hooks,
 			// long ReadTimeout because some autobahn test cases (e.g. 5.19
 			// sleep up to 1 second between frames)
-			ReadTimeout:  2000 * time.Millisecond,
+			ReadTimeout:  5000 * time.Millisecond,
 			WriteTimeout: 500 * time.Millisecond,
 			// some autobahn test cases send large frames, so we need to
 			// support large fragments and messages
@@ -117,21 +117,19 @@ func TestWebSocketServer(t *testing.T) {
 		t.Fatalf("empty autobahn test summary; check autobahn logs for problems connecting to test server at %q", targetURL)
 	}
 
-	for _, results := range summary {
-		for caseName, result := range results {
-			result := result
-			t.Run("autobahn/"+caseName, func(t *testing.T) {
-				if result.Failed() {
-					report := loadReport(t, testDir, result.ReportFile)
-					t.Errorf("description: %s", report.Description)
-					t.Errorf("expectation: %s", report.Expectation)
-					t.Errorf("want result: %s", report.Result)
-					t.Errorf("got result:  %s", report.Behavior)
-					t.Errorf("want close:  %s", report.ResultClose)
-					t.Errorf("got close:   %s", report.BehaviorClose)
-				}
-			})
-		}
+	for _, result := range summary {
+		result := result
+		t.Run("autobahn/"+result.ID, func(t *testing.T) {
+			if result.Failed() {
+				report := loadReport(t, testDir, result.ReportFile)
+				t.Errorf("description: %s", report.Description)
+				t.Errorf("expectation: %s", report.Expectation)
+				t.Errorf("want result: %s", report.Result)
+				t.Errorf("got result:  %s", report.Behavior)
+				t.Errorf("want close:  %s", report.ResultClose)
+				t.Errorf("got close:   %s", report.BehaviorClose)
+			}
+		})
 	}
 
 	t.Logf("autobahn test report: file://%s", path.Join(testDir, "report/index.html"))
@@ -188,14 +186,21 @@ func newTestDir(t *testing.T) string {
 	return testDir
 }
 
-func loadSummary(t *testing.T, testDir string) autobahnReportSummary {
+func loadSummary(t *testing.T, testDir string) []autobahnReportResult {
 	t.Helper()
 	f, err := os.Open(path.Join(testDir, "report", "index.json"))
 	assert.NilError(t, err)
 	defer f.Close()
 	var summary autobahnReportSummary
 	assert.NilError(t, json.NewDecoder(f).Decode(&summary))
-	return summary
+	var results []autobahnReportResult
+	for _, serverResults := range summary {
+		for id, result := range serverResults {
+			result.ID = id
+			results = append(results, result)
+		}
+	}
+	return results
 }
 
 func loadReport(t *testing.T, testDir string, reportFile string) autobahnReportResult {
@@ -210,9 +215,10 @@ func loadReport(t *testing.T, testDir string, reportFile string) autobahnReportR
 	return report
 }
 
-type autobahnReportSummary map[string]map[string]autobahnReportResult
+type autobahnReportSummary map[string]map[string]autobahnReportResult // server -> case -> result
 
 type autobahnReportResult struct {
+	ID            string `json:"id"`
 	Behavior      string `json:"behavior"`
 	BehaviorClose string `json:"behaviorClose"`
 	Description   string `json:"description"`
@@ -226,6 +232,22 @@ func (r autobahnReportResult) Failed() bool {
 	okayBehavior := map[string]bool{
 		"OK":            true,
 		"INFORMATIONAL": true,
+	}
+	allowNonStrict := map[string]bool{
+		// Some weirdness in these test cases, where they expect the server to
+		// time out and close the connection, but it's not clear after exactly
+		// how long the timeout should happen (and, AFAICT, other test cases
+		// expect a different timeout).
+		//
+		// The cases pass with "NON-STRICT" results when the timeout is not
+		// hit, as long as we return the expected 1007 status code.
+		"6.4.1": true,
+		"6.4.2": true,
+		"6.4.3": true,
+		"6.4.4": true,
+	}
+	if allowNonStrict[r.ID] {
+		okayBehavior["NON-STRICT"] = true
 	}
 	return !(okayBehavior[r.Behavior] && okayBehavior[r.BehaviorClose])
 }

--- a/websocket_autobahn_test.go
+++ b/websocket_autobahn_test.go
@@ -54,16 +54,16 @@ func TestWebSocketServer(t *testing.T) {
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ws := websocket.New(w, r, websocket.Limits{
+		ws, err := websocket.Accept(w, r, websocket.Limits{
 			MaxDuration:     30 * time.Second,
 			MaxFragmentSize: 1024 * 1024 * 16,
 			MaxMessageSize:  1024 * 1024 * 16,
 		})
-		if err := ws.Handshake(); err != nil {
+		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		ws.Serve(websocket.EchoHandler)
+		ws.Serve(r.Context(), websocket.EchoHandler)
 	}))
 	defer srv.Close()
 

--- a/websocket_autobahn_test.go
+++ b/websocket_autobahn_test.go
@@ -26,13 +26,6 @@ var defaultIncludedTestCases = []string{
 }
 
 var defaultExcludedTestCases = []string{
-	// These cases all seem to rely on the server accepting fragmented text
-	// frames with invalid utf8 payloads, but the spec seems to indicate that
-	// every text fragment must be valid utf8 on its own.
-	"6.2.3",
-	"6.2.4",
-	"6.4.2",
-
 	// Compression extensions are not supported
 	"12.*",
 	"13.*",

--- a/websocket_autobahn_test.go
+++ b/websocket_autobahn_test.go
@@ -60,7 +60,7 @@ func TestWebSocketServer(t *testing.T) {
 			Hooks: hooks,
 			// long ReadTimeout because some autobahn test cases (e.g. 5.19
 			// sleep up to 1 second between frames)
-			ReadTimeout:  1000 * time.Millisecond,
+			ReadTimeout:  2000 * time.Millisecond,
 			WriteTimeout: 500 * time.Millisecond,
 			// some autobahn test cases send large frames, so we need to
 			// support large fragments and messages

--- a/websocket_autobahn_test.go
+++ b/websocket_autobahn_test.go
@@ -38,32 +38,6 @@ var defaultExcludedTestCases = []string{
 	"13.*",
 }
 
-func newTestHooks(t *testing.T) websocket.Hooks {
-	return websocket.Hooks{
-		OnClose: func(key websocket.ClientKey, code websocket.StatusCode, err error) {
-			t.Logf("client=%s OnClose code=%v err=%q", key, code, err)
-		},
-		OnReadError: func(key websocket.ClientKey, err error) {
-			t.Logf("client=%s OnReadError err=%q", key, err)
-		},
-		OnReadFrame: func(key websocket.ClientKey, frame *websocket.Frame) {
-			t.Logf("client=%s OnReadFrame frame=%#v", key, frame)
-		},
-		OnReadMessage: func(key websocket.ClientKey, msg *websocket.Message) {
-			t.Logf("client=%s OnReadMessage msg=%#v", key, msg)
-		},
-		OnWriteError: func(key websocket.ClientKey, err error) {
-			t.Logf("client=%s OnWriteError err=%q", key, err)
-		},
-		OnWriteFrame: func(key websocket.ClientKey, frame *websocket.Frame) {
-			t.Logf("client=%s OnWriteFrame frame=%#v", key, frame)
-		},
-		OnWriteMessage: func(key websocket.ClientKey, msg *websocket.Message) {
-			t.Logf("client=%s OnWriteMessage msg=%#v", key, msg)
-		},
-	}
-}
-
 func TestWebSocketServer(t *testing.T) {
 	t.Parallel()
 
@@ -84,7 +58,8 @@ func TestWebSocketServer(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ws, err := websocket.Accept(w, r, websocket.Options{
 			Hooks:           hooks,
-			MaxDuration:     30 * time.Second,
+			ReadTimeout:     500 * time.Millisecond,
+			WriteTimeout:    500 * time.Millisecond,
 			MaxFragmentSize: 1024 * 1024 * 16,
 			MaxMessageSize:  1024 * 1024 * 16,
 		})

--- a/websocket_autobahn_test.go
+++ b/websocket_autobahn_test.go
@@ -117,7 +117,7 @@ func TestWebSocketServer(t *testing.T) {
 		for caseName, result := range results {
 			result := result
 			t.Run("autobahn/"+caseName, func(t *testing.T) {
-				if result.Behavior == "FAILED" || result.BehaviorClose == "FAILED" {
+				if result.Failed() {
 					report := loadReport(t, testDir, result.ReportFile)
 					t.Errorf("description: %s", report.Description)
 					t.Errorf("expectation: %s", report.Expectation)
@@ -128,7 +128,7 @@ func TestWebSocketServer(t *testing.T) {
 		}
 	}
 
-	t.Logf("autobahn test report: %s", path.Join(testDir, "report/index.html"))
+	t.Logf("autobahn test report: file://%s", path.Join(testDir, "report/index.html"))
 	if os.Getenv("AUTOBAHN_OPEN_REPORT") != "" {
 		runCmd(t, exec.Command("open", path.Join(testDir, "report/index.html")))
 	}
@@ -214,4 +214,8 @@ type autobahnReportResult struct {
 	ReportFile    string `json:"reportfile"`
 	Result        string `json:"result"`
 	ResultClose   string `json:"resultClose"`
+}
+
+func (r autobahnReportResult) Failed() bool {
+	return r.Behavior != "OK" || r.BehaviorClose != "OK"
 }

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -187,7 +186,8 @@ func TestAccept(t *testing.T) {
 }
 
 func TestConnectionLimits(t *testing.T) {
-	// XXX FIXME: need to rework this in terms of read/write deadlines!
+	// TODO: need to rework these tests in terms of read/write deadlines rather
+	// than total request time.
 	t.Run("server enforces read deadline", func(t *testing.T) {
 		t.Parallel()
 
@@ -385,25 +385,25 @@ func newTestHooks(t *testing.T) websocket.Hooks {
 	t.Helper()
 	return websocket.Hooks{
 		OnClose: func(key websocket.ClientKey, code websocket.StatusCode, err error) {
-			log.Printf("XXX hook client=%s OnClose code=%v err=%q", key, code, err)
+			t.Logf("client=%s OnClose code=%v err=%q", key, code, err)
 		},
 		OnReadError: func(key websocket.ClientKey, err error) {
-			log.Printf("XXX hook client=%s OnReadError err=%q", key, err)
+			t.Logf("client=%s OnReadError err=%q", key, err)
 		},
 		OnReadFrame: func(key websocket.ClientKey, frame *websocket.Frame) {
-			log.Printf("XXX hook client=%s OnReadFrame frame=%#v", key, frame)
+			t.Logf("client=%s OnReadFrame frame=%#v", key, frame)
 		},
 		OnReadMessage: func(key websocket.ClientKey, msg *websocket.Message) {
-			log.Printf("XXX hook client=%s OnReadMessage msg=%#v", key, msg)
+			t.Logf("client=%s OnReadMessage msg=%#v", key, msg)
 		},
 		OnWriteError: func(key websocket.ClientKey, err error) {
-			log.Printf("XXX hook client=%s OnWriteError err=%q", key, err)
+			t.Logf("client=%s OnWriteError err=%q", key, err)
 		},
 		OnWriteFrame: func(key websocket.ClientKey, frame *websocket.Frame) {
-			log.Printf("XXX hook client=%s OnWriteFrame frame=%#v", key, frame)
+			t.Logf("client=%s OnWriteFrame frame=%#v", key, frame)
 		},
 		OnWriteMessage: func(key websocket.ClientKey, msg *websocket.Message) {
-			log.Printf("XXX hook client=%s OnWriteMessage msg=%#v", key, msg)
+			t.Logf("client=%s OnWriteMessage msg=%#v", key, msg)
 		},
 	}
 }

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -117,7 +117,7 @@ func TestAccept(t *testing.T) {
 			t.Parallel()
 
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				ws, err := websocket.Accept(w, r, websocket.Limits{})
+				ws, err := websocket.Accept(w, r, websocket.Options{})
 				if err != nil {
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return
@@ -167,7 +167,7 @@ func TestAccept(t *testing.T) {
 				}
 				assert.Equal(t, fmt.Sprint(r), "websocket: accept: server does not support hijacking", "incorrect panic message")
 			}()
-			websocket.Accept(w, handshakeReq, websocket.Limits{})
+			websocket.Accept(w, handshakeReq, websocket.Options{})
 		})
 
 		t.Run("hijack failed", func(t *testing.T) {
@@ -178,7 +178,7 @@ func TestAccept(t *testing.T) {
 				}
 				assert.Equal(t, fmt.Sprint(r), "websocket: accept: hijack failed: error hijacking connection", "incorrect panic message")
 			}()
-			websocket.Accept(&brokenHijackResponseWriter{}, handshakeReq, websocket.Limits{})
+			websocket.Accept(&brokenHijackResponseWriter{}, handshakeReq, websocket.Options{})
 		})
 	}
 }
@@ -190,7 +190,7 @@ func TestConnectionLimits(t *testing.T) {
 		maxDuration := 500 * time.Millisecond
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ws, err := websocket.Accept(w, r, websocket.Limits{
+			ws, err := websocket.Accept(w, r, websocket.Options{
 				MaxDuration: maxDuration,
 				// TODO: test these limits as well
 				MaxFragmentSize: 128,
@@ -261,7 +261,7 @@ func TestConnectionLimits(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer wg.Done()
 			start := time.Now()
-			ws, err := websocket.Accept(w, r, websocket.Limits{
+			ws, err := websocket.Accept(w, r, websocket.Options{
 				MaxDuration:     serverTimeout,
 				MaxFragmentSize: 128,
 				MaxMessageSize:  256,

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -170,7 +170,7 @@ func TestAccept(t *testing.T) {
 				}
 				assert.Equal(t, fmt.Sprint(r), "websocket: accept: server does not support hijacking", "incorrect panic message")
 			}()
-			websocket.Accept(w, handshakeReq, websocket.Options{})
+			_, _ = websocket.Accept(w, handshakeReq, websocket.Options{})
 		})
 
 		t.Run("hijack failed", func(t *testing.T) {
@@ -181,7 +181,7 @@ func TestAccept(t *testing.T) {
 				}
 				assert.Equal(t, fmt.Sprint(r), "websocket: accept: hijack failed: error hijacking connection", "incorrect panic message")
 			}()
-			websocket.Accept(&brokenHijackResponseWriter{}, handshakeReq, websocket.Options{})
+			_, _ = websocket.Accept(&brokenHijackResponseWriter{}, handshakeReq, websocket.Options{})
 		})
 	}
 }


### PR DESCRIPTION
This is an unreviewable mess, but here are the highlights:

- Revisit handshake API to make it easier to use correctly
- Split websocket server API into low-level (Read/Write) and high level (Serve) implementations
- Add connection lifecycle hooks for debugging/instrumentation
- Fix various small protocol bugs and misunderstandings
  - Only validate UTF8 on full messages, not fragments
  - Don't require masking in low level proto impl, so it can be used to read in test clients
 - etc

Still lots to clean up and improve, but stopping here as a checkpoint before this gets even more unwieldy!