### PR TITLE
refactor: abstract over underlying connection, export websocket constructor

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -105,7 +105,7 @@ func NewConn(src io.ReadWriteCloser, clientKey ClientKey, opts Options) *Conn {
 	setDefaults(&opts)
 	if opts.ReadTimeout != 0 || opts.WriteTimeout != 0 {
 		if _, ok := src.(deadliner); !ok {
-			panic(fmt.Sprintf("ReadTimeout and WriteTimeout may only be used when input source supports setting read/write deadlines"))
+			panic("ReadTimeout and WriteTimeout may only be used when input source supports setting read/write deadlines")
 		}
 	}
 	return &Conn{

--- a/websocket_benchmark_test.go
+++ b/websocket_benchmark_test.go
@@ -61,16 +61,16 @@ func BenchmarkReadFrame(b *testing.B) {
 func BenchmarkReadMessage(b *testing.B) {
 	frameSizes := []int{
 		64,
-		// 256,
-		// 1024,
+		256,
+		1024,
 		// 64 * 1024,
 		// 1024 * 1024,
 	}
 
 	messageSizes := []int{
 		512,
-		// 1024,
-		// 256 * 1024,
+		1024,
+		256 * 1024,
 		// 1024 * 1024,
 		// 2 * 1024 * 1024,
 	}
@@ -109,7 +109,6 @@ func BenchmarkReadMessage(b *testing.B) {
 			b.Run(name, func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					_, _ = reader.Seek(0, 0)
-					b.ResetTimer()
 					msg, err := ws.Read(context.Background())
 					assert.NilError(b, err)
 					assert.Equal(b, len(msg.Payload), msgSize, "expected message payload")

--- a/websocket_internal_test.go
+++ b/websocket_internal_test.go
@@ -1,7 +1,6 @@
 package websocket
 
 import (
-	"bufio"
 	"net"
 	"testing"
 
@@ -13,10 +12,9 @@ func TestDefaults(t *testing.T) {
 
 	var (
 		wrapedConn net.Conn
-		wrappedBuf *bufio.ReadWriter
 		key        = ClientKey("test-client-key")
 		opts       = Options{}
-		conn       = newConn(wrapedConn, wrappedBuf, key, opts)
+		conn       = NewConn(wrapedConn, key, opts)
 	)
 
 	assert.Equal(t, conn.maxFragmentSize, DefaultMaxFragmentSize, "incorrect max fragment size")


### PR DESCRIPTION
In pursuit of better testability and better benchmarks:
- allow directly instantiating a websocket connection
- work with an io.ReadWriteCloser rather than requiring an actual net.Conn and associated bufio.ReadWriter