### PR TITLE
refactor: renaming for clarity and consistency

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -1,0 +1,45 @@
+package websocket
+
+// Hooks define the callbacks that are called during the lifecycle of a
+// websocket connection.
+type Hooks struct {
+	// OnClose is called when the connection is closed.
+	OnClose func(ClientKey, StatusCode, error)
+	// OnReadError is called when a read error occurs.
+	OnReadError func(ClientKey, error)
+	// OnReadFrame is called when a frame is read.
+	OnReadFrame func(ClientKey, *Frame)
+	// OnReadMessage is called when a complete message is read.
+	OnReadMessage func(ClientKey, *Message)
+	// OnWriteError is called when a write error occurs.
+	OnWriteError func(ClientKey, error)
+	// OnWriteFrame is called when a frame is written.
+	OnWriteFrame func(ClientKey, *Frame)
+	// OnWriteMessage is called when a complete message is written.
+	OnWriteMessage func(ClientKey, *Message)
+}
+
+// setupHooks ensures that all hooks have a default no-op function if unset.
+func setupHooks(hooks *Hooks) {
+	if hooks.OnClose == nil {
+		hooks.OnClose = func(ClientKey, StatusCode, error) {}
+	}
+	if hooks.OnReadError == nil {
+		hooks.OnReadError = func(ClientKey, error) {}
+	}
+	if hooks.OnReadFrame == nil {
+		hooks.OnReadFrame = func(ClientKey, *Frame) {}
+	}
+	if hooks.OnReadMessage == nil {
+		hooks.OnReadMessage = func(ClientKey, *Message) {}
+	}
+	if hooks.OnWriteError == nil {
+		hooks.OnWriteError = func(ClientKey, error) {}
+	}
+	if hooks.OnWriteFrame == nil {
+		hooks.OnWriteFrame = func(ClientKey, *Frame) {}
+	}
+	if hooks.OnWriteMessage == nil {
+		hooks.OnWriteMessage = func(ClientKey, *Message) {}
+	}
+}

--- a/websocket.go
+++ b/websocket.go
@@ -38,32 +38,13 @@ type Options struct {
 	MaxMessageSize  int
 }
 
-// Hooks define the callbacks that are called during the lifecycle of a
-// websocket connection.
-type Hooks struct {
-	// OnClose is called when the connection is closed.
-	OnClose func(ClientKey, StatusCode, error)
-	// OnReadError is called when a read error occurs.
-	OnReadError func(ClientKey, error)
-	// OnReadFrame is called when a frame is read.
-	OnReadFrame func(ClientKey, *Frame)
-	// OnReadMessage is called when a complete message is read.
-	OnReadMessage func(ClientKey, *Message)
-	// OnWriteError is called when a write error occurs.
-	OnWriteError func(ClientKey, error)
-	// OnWriteFrame is called when a frame is written.
-	OnWriteFrame func(ClientKey, *Frame)
-	// OnWriteMessage is called when a complete message is written.
-	OnWriteMessage func(ClientKey, *Message)
-}
-
 type deadliner interface {
 	SetReadDeadline(time.Time) error
 	SetWriteDeadline(time.Time) error
 }
 
-// Conn is a websocket connection.
-type Conn struct {
+// Websocket is a websocket connection.
+type Websocket struct {
 	// connection state
 	conn     io.ReadWriteCloser
 	closedCh chan struct{}
@@ -80,8 +61,9 @@ type Conn struct {
 	maxMessageSize  int
 }
 
-// Accept upgrades an HTTP connection to a websocket connection.
-func Accept(w http.ResponseWriter, r *http.Request, opts Options) (*Conn, error) {
+// Accept handles the initial HTTP-based handshake and upgrades the TCP
+// connection to a websocket connection.
+func Accept(w http.ResponseWriter, r *http.Request, opts Options) (*Websocket, error) {
 	clientKey, err := handshake(w, r)
 	if err != nil {
 		return nil, fmt.Errorf("websocket: accept: handshake failed: %w", err)
@@ -97,18 +79,21 @@ func Accept(w http.ResponseWriter, r *http.Request, opts Options) (*Conn, error)
 		panic(fmt.Errorf("websocket: accept: hijack failed: %s", err))
 	}
 
-	return NewConn(conn, clientKey, opts), nil
+	return New(conn, clientKey, opts), nil
 }
 
-// NewConn creates a new websocket connection.
-func NewConn(src io.ReadWriteCloser, clientKey ClientKey, opts Options) *Conn {
+// New manually creates a new websocket connection. Caller is responsible for
+// completing initial handshake before creating a websocket connection.
+//
+// Prefer Accept() when possible.
+func New(src io.ReadWriteCloser, clientKey ClientKey, opts Options) *Websocket {
 	setDefaults(&opts)
 	if opts.ReadTimeout != 0 || opts.WriteTimeout != 0 {
 		if _, ok := src.(deadliner); !ok {
 			panic("ReadTimeout and WriteTimeout may only be used when input source supports setting read/write deadlines")
 		}
 	}
-	return &Conn{
+	return &Websocket{
 		conn:            src,
 		closedCh:        make(chan struct{}),
 		server:          true,
@@ -130,31 +115,6 @@ func setDefaults(opts *Options) {
 		opts.MaxMessageSize = DefaultMaxMessageSize
 	}
 	setupHooks(&opts.Hooks)
-}
-
-// setupHooks ensures that all hooks have a default no-op function if unset.
-func setupHooks(hooks *Hooks) {
-	if hooks.OnClose == nil {
-		hooks.OnClose = func(ClientKey, StatusCode, error) {}
-	}
-	if hooks.OnReadError == nil {
-		hooks.OnReadError = func(ClientKey, error) {}
-	}
-	if hooks.OnReadFrame == nil {
-		hooks.OnReadFrame = func(ClientKey, *Frame) {}
-	}
-	if hooks.OnReadMessage == nil {
-		hooks.OnReadMessage = func(ClientKey, *Message) {}
-	}
-	if hooks.OnWriteError == nil {
-		hooks.OnWriteError = func(ClientKey, error) {}
-	}
-	if hooks.OnWriteFrame == nil {
-		hooks.OnWriteFrame = func(ClientKey, *Frame) {}
-	}
-	if hooks.OnWriteMessage == nil {
-		hooks.OnWriteMessage = func(ClientKey, *Message) {}
-	}
 }
 
 // handshake validates the request and performs the WebSocket handshake, after
@@ -179,38 +139,39 @@ func handshake(w http.ResponseWriter, r *http.Request) (ClientKey, error) {
 	return ClientKey(clientKey), nil
 }
 
-// Read reads a single websocket message from the connection. Ping/pong frames
-// are handled automatically. The connection will be closed on any error.
-func (c *Conn) Read(ctx context.Context) (*Message, error) {
+// ReadMessage reads a single websocket message from the connection,
+// handling fragments and control frames automatically. frames are handled
+// automatically. The connection will be closed on any error.
+func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 	var msg *Message
 	for {
 		select {
-		case <-c.closedCh:
+		case <-ws.closedCh:
 			return nil, io.EOF
 		case <-ctx.Done():
-			_ = c.Close()
+			_ = ws.Close()
 			return nil, ctx.Err()
 		default:
-			c.resetReadDeadline()
+			ws.resetReadDeadline()
 		}
 
-		frame, err := ReadFrame(c.conn)
+		frame, err := ReadFrame(ws.conn)
 		if err != nil {
 			code := StatusServerError
 			if errors.Is(err, io.EOF) {
 				code = StatusNormalClosure
 			}
-			return nil, c.closeOnReadError(code, err)
+			return nil, ws.closeOnReadError(code, err)
 		}
-		if err := validateFrame(frame, c.maxFragmentSize, c.server); err != nil {
-			return nil, c.closeOnReadError(StatusProtocolError, err)
+		if err := validateFrame(frame, ws.maxFragmentSize, ws.server); err != nil {
+			return nil, ws.closeOnReadError(StatusProtocolError, err)
 		}
-		c.hooks.OnReadFrame(c.clientKey, frame)
+		ws.hooks.OnReadFrame(ws.clientKey, frame)
 
 		switch frame.Opcode {
 		case OpcodeBinary, OpcodeText:
 			if msg != nil {
-				return nil, c.closeOnReadError(StatusProtocolError, ErrContinuationExpected)
+				return nil, ws.closeOnReadError(StatusProtocolError, ErrContinuationExpected)
 			}
 			msg = &Message{
 				Binary:  frame.Opcode == OpcodeBinary,
@@ -218,66 +179,66 @@ func (c *Conn) Read(ctx context.Context) (*Message, error) {
 			}
 		case OpcodeContinuation:
 			if msg == nil {
-				return nil, c.closeOnReadError(StatusProtocolError, ErrInvalidContinuation)
+				return nil, ws.closeOnReadError(StatusProtocolError, ErrInvalidContinuation)
 			}
 			msg.Payload = append(msg.Payload, frame.Payload...)
-			if len(msg.Payload) > c.maxMessageSize {
-				return nil, c.closeOnReadError(StatusTooLarge, fmt.Errorf("message size %d exceeds maximum of %d bytes", len(msg.Payload), c.maxMessageSize))
+			if len(msg.Payload) > ws.maxMessageSize {
+				return nil, ws.closeOnReadError(StatusTooLarge, fmt.Errorf("message size %d exceeds maximum of %d bytes", len(msg.Payload), ws.maxMessageSize))
 			}
 		case OpcodeClose:
-			_ = c.Close()
+			_ = ws.Close()
 			return nil, io.EOF
 		case OpcodePing:
 			frame.Opcode = OpcodePong
-			c.hooks.OnWriteFrame(c.clientKey, frame)
-			if err := WriteFrame(c.conn, frame); err != nil {
+			ws.hooks.OnWriteFrame(ws.clientKey, frame)
+			if err := WriteFrame(ws.conn, frame); err != nil {
 				return nil, err
 			}
 			continue
 		case OpcodePong:
 			continue // no-op
 		default:
-			return nil, c.closeOnReadError(StatusProtocolError, fmt.Errorf("unsupported opcode: %v", frame.Opcode))
+			return nil, ws.closeOnReadError(StatusProtocolError, fmt.Errorf("unsupported opcode: %v", frame.Opcode))
 		}
 
 		if frame.Fin {
-			c.hooks.OnReadMessage(c.clientKey, msg)
+			ws.hooks.OnReadMessage(ws.clientKey, msg)
 			if !msg.Binary && !utf8.Valid(msg.Payload) {
-				return nil, c.closeOnReadError(StatusUnsupportedPayload, ErrInvalidUT8)
+				return nil, ws.closeOnReadError(StatusUnsupportedPayload, ErrInvalidUT8)
 			}
 			return msg, nil
 		}
 	}
 }
 
-// Write writes a single websocket message to the connection, after splitting
-// it into fragments (if necessary). The connection will be closed on any
-// error.
-func (c *Conn) Write(ctx context.Context, msg *Message) error {
-	c.hooks.OnWriteMessage(c.clientKey, msg)
-	for _, frame := range messageFrames(msg, c.maxFragmentSize) {
-		c.hooks.OnWriteFrame(c.clientKey, frame)
+// WriteMessage writes a single websocket message to the connection, after
+// splitting it into fragments (if necessary). The connection will be closed
+// on any error.
+func (ws *Websocket) WriteMessage(ctx context.Context, msg *Message) error {
+	ws.hooks.OnWriteMessage(ws.clientKey, msg)
+	for _, frame := range messageFrames(msg, ws.maxFragmentSize) {
+		ws.hooks.OnWriteFrame(ws.clientKey, frame)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-c.closedCh:
+		case <-ws.closedCh:
 			return io.EOF
 		default:
-			c.resetWriteDeadline()
+			ws.resetWriteDeadline()
 		}
-		if err := WriteFrame(c.conn, frame); err != nil {
-			return c.closeOnWriteError(StatusServerError, err)
+		if err := WriteFrame(ws.conn, frame); err != nil {
+			return ws.closeOnWriteError(StatusServerError, err)
 		}
 	}
 	return nil
 }
 
-// Serve is a basic high-level handler for a request-response style websocket
-// connection, where handler is called for each incoming message and its return
-// value is sent back to the client.
-func (c *Conn) Serve(ctx context.Context, handler Handler) {
+// Serve is a high-level convienience method for request-response style
+// websocket connections, where handler is called for each incoming message
+// and its return value is sent back to the client.
+func (ws *Websocket) Serve(ctx context.Context, handler Handler) {
 	for {
-		msg, err := c.Read(ctx)
+		msg, err := ws.ReadMessage(ctx)
 		if err != nil {
 			// an error in Read() closes the connection
 			return
@@ -285,12 +246,11 @@ func (c *Conn) Serve(ctx context.Context, handler Handler) {
 
 		resp, err := handler(ctx, msg)
 		if err != nil {
-			_ = c.closeWithError(StatusServerError, err)
+			_ = ws.closeWithError(StatusServerError, err)
 			return
 		}
-
 		if resp != nil {
-			if err := c.Write(ctx, resp); err != nil {
+			if err := ws.WriteMessage(ctx, resp); err != nil {
 				// an error in Write() closes the connection
 				return
 			}
@@ -299,48 +259,48 @@ func (c *Conn) Serve(ctx context.Context, handler Handler) {
 }
 
 // Close closes a websocket connection.
-func (c *Conn) Close() error {
-	return c.closeWithError(StatusNormalClosure, nil)
+func (ws *Websocket) Close() error {
+	return ws.closeWithError(StatusNormalClosure, nil)
 }
 
-func (c *Conn) closeWithError(code StatusCode, err error) error {
-	c.hooks.OnClose(c.clientKey, code, err)
-	close(c.closedCh)
-	if err := writeCloseFrame(c.conn, code, err); err != nil {
+func (ws *Websocket) closeWithError(code StatusCode, err error) error {
+	ws.hooks.OnClose(ws.clientKey, code, err)
+	close(ws.closedCh)
+	if err := writeCloseFrame(ws.conn, code, err); err != nil {
 		return fmt.Errorf("websocket: failed to write close frame: %w", err)
 	}
-	if err := c.conn.Close(); err != nil {
+	if err := ws.conn.Close(); err != nil {
 		return fmt.Errorf("websocket: failed to close connection: %s", err)
 	}
 	return nil
 }
 
-func (c *Conn) closeOnReadError(code StatusCode, err error) error {
-	c.hooks.OnReadError(c.clientKey, err)
-	_ = c.closeWithError(code, err)
+func (ws *Websocket) closeOnReadError(code StatusCode, err error) error {
+	ws.hooks.OnReadError(ws.clientKey, err)
+	_ = ws.closeWithError(code, err)
 	return err
 }
 
-func (c *Conn) closeOnWriteError(code StatusCode, err error) error {
-	c.hooks.OnWriteError(c.clientKey, err)
-	_ = c.closeWithError(code, err)
+func (ws *Websocket) closeOnWriteError(code StatusCode, err error) error {
+	ws.hooks.OnWriteError(ws.clientKey, err)
+	_ = ws.closeWithError(code, err)
 	return err
 }
 
-func (c *Conn) resetReadDeadline() {
-	if c.readTimeout <= 0 {
+func (ws *Websocket) resetReadDeadline() {
+	if ws.readTimeout <= 0 {
 		return
 	}
-	if err := c.conn.(deadliner).SetReadDeadline(time.Now().Add(c.readTimeout)); err != nil {
+	if err := ws.conn.(deadliner).SetReadDeadline(time.Now().Add(ws.readTimeout)); err != nil {
 		panic(fmt.Sprintf("websocket: failed to set read deadline: %s", err))
 	}
 }
 
-func (c *Conn) resetWriteDeadline() {
-	if c.writeTimeout <= 0 {
+func (ws *Websocket) resetWriteDeadline() {
+	if ws.writeTimeout <= 0 {
 		return
 	}
-	if err := c.conn.(deadliner).SetWriteDeadline(time.Now().Add(c.writeTimeout)); err != nil {
+	if err := ws.conn.(deadliner).SetWriteDeadline(time.Now().Add(ws.writeTimeout)); err != nil {
 		panic(fmt.Sprintf("websocket: failed to set write deadline: %s", err))
 	}
 }

--- a/websocket_benchmark_test.go
+++ b/websocket_benchmark_test.go
@@ -99,7 +99,7 @@ func BenchmarkReadMessage(b *testing.B) {
 				in:  reader,
 				out: io.Discard,
 			}
-			ws := websocket.NewConn(conn, websocket.ClientKey(makeClientKey()), websocket.Options{
+			ws := websocket.New(conn, websocket.ClientKey(makeClientKey()), websocket.Options{
 				MaxFragmentSize: 1024 * 1024,
 				MaxMessageSize:  2 * 1024 * 1024,
 				// Hooks:           newTestHooks(b),
@@ -109,7 +109,7 @@ func BenchmarkReadMessage(b *testing.B) {
 			b.Run(name, func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					_, _ = reader.Seek(0, 0)
-					msg, err := ws.Read(context.Background())
+					msg, err := ws.ReadMessage(context.Background())
 					assert.NilError(b, err)
 					assert.Equal(b, len(msg.Payload), msgSize, "expected message payload")
 				}

--- a/websocket_internal_test.go
+++ b/websocket_internal_test.go
@@ -14,7 +14,7 @@ func TestDefaults(t *testing.T) {
 		wrapedConn net.Conn
 		key        = ClientKey("test-client-key")
 		opts       = Options{}
-		conn       = NewConn(wrapedConn, key, opts)
+		conn       = New(wrapedConn, key, opts)
 	)
 
 	assert.Equal(t, conn.maxFragmentSize, DefaultMaxFragmentSize, "incorrect max fragment size")


### PR DESCRIPTION
The renames:

    websocket.Conn    -> websocket.Websocket
    websocket.NewConn -> websocket.New
    Read              -> ReadMessage
    Write             -> WriteMessage

