### PR TITLE
fix: truncate large frames/messages in test hooks

### DIFF
--- a/proto.go
+++ b/proto.go
@@ -90,7 +90,7 @@ type Frame struct {
 }
 
 func (f Frame) String() string {
-	return fmt.Sprintf("Frame{Fin: %v, Opcode: %v, Payload: %q}", f.Fin, f.Opcode, f.Payload)
+	return fmt.Sprintf("Frame{Fin: %v, Opcode: %v, Payload: %q}", f.Fin, f.Opcode, truncatedPayload(f.Payload, 512))
 }
 
 // Message is an application-level message from the client, which may be
@@ -102,9 +102,17 @@ type Message struct {
 
 func (m Message) String() string {
 	if m.Binary {
-		return fmt.Sprintf("Message{Binary: %v, Payload: %v}", m.Binary, m.Payload)
+		return fmt.Sprintf("Message{Binary: %v, Payload: %v}", m.Binary, truncatedPayload(m.Payload, 512))
 	}
-	return fmt.Sprintf("Message{Binary: %v, Payload: %q}", m.Binary, m.Payload)
+	return fmt.Sprintf("Message{Binary: %v, Payload: %q}", m.Binary, truncatedPayload(m.Payload, 512))
+}
+
+func truncatedPayload(p []byte, limit int) string {
+	if len(p) < limit {
+		return string(p)
+	}
+	suffix := fmt.Sprintf(" ... [%d bytes truncated]", len(p)-limit)
+	return string(p[:limit]) + suffix
 }
 
 // ReadFrame reads a websocket frame from the wire.

--- a/websocket_autobahn_test.go
+++ b/websocket_autobahn_test.go
@@ -51,8 +51,8 @@ func TestWebSocketServer(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ws, err := websocket.Accept(w, r, websocket.Options{
 			Hooks: hooks,
-			// long ReadTimeout because some autobahn test cases (e.g. 5.19
-			// sleep up to 1 second between frames)
+			// long ReadTimeout because some autobahn test cases (e.g. 5.19)
+			// sleep up to 1 second between frames
 			ReadTimeout:  5000 * time.Millisecond,
 			WriteTimeout: 500 * time.Millisecond,
 			// some autobahn test cases send large frames, so we need to


### PR DESCRIPTION
It appears that the test hooks used when running the autobahn test suite can contribute to excessive latency when logging the 8 to 16mb frame and message payloads in some of the extreme test cases.  For now, let's truncate payloads over an arbitrary length.