### PR TITLE
refactor: experiment with callers providing buffers

### DIFF
--- a/proto.go
+++ b/proto.go
@@ -88,6 +88,7 @@ type Frame struct {
 	Opcode  Opcode
 	Payload []byte
 	Masked  bool
+	Size    int
 }
 
 func (f Frame) String() string {
@@ -211,6 +212,7 @@ func ReadFrame(src io.Reader, buf []byte, maxPayloadSize int) (*Frame, error) {
 		Opcode:  opcode,
 		Payload: payload,
 		Masked:  masked,
+		Size:    int(payloadLen),
 	}, nil
 }
 

--- a/proto.go
+++ b/proto.go
@@ -116,16 +116,24 @@ func truncatedPayload(p []byte, limit int) string {
 	return string(p[:limit]) + suffix
 }
 
-// ReadFrame reads a websocket frame from the wire.
-func ReadFrame(buf io.Reader, maxPayloadLen int) (*Frame, error) {
-	bb := make([]byte, 2)
-	if _, err := io.ReadFull(buf, bb); err != nil {
+const (
+	frameHeaderSize     = 2
+	frameMaskingKeySize = 4
+)
+
+// ReadFrame reads a websocket frame.
+func ReadFrame(src io.Reader, buf []byte, maxPayloadSize int) (*Frame, error) {
+	bufLen := len(buf)
+	if bufLen < frameHeaderSize {
+		return nil, fmt.Errorf("buffer too small for frame header")
+	}
+	if _, err := io.ReadFull(src, buf[:frameHeaderSize]); err != nil {
 		return nil, fmt.Errorf("error reading frame header: %w", err)
 	}
 
 	// parse first header byte
 	var (
-		b0     = bb[0]
+		b0     = buf[0]
 		fin    = b0&0b10000000 != 0
 		rsv1   = b0&0b01000000 != 0
 		rsv2   = b0&0b00100000 != 0
@@ -135,7 +143,7 @@ func ReadFrame(buf io.Reader, maxPayloadLen int) (*Frame, error) {
 
 	// parse second header byte
 	var (
-		b1         = bb[1]
+		b1         = buf[1]
 		masked     = b1&0b10000000 != 0
 		payloadLen = uint64(b1 & 0b01111111)
 	)
@@ -144,39 +152,47 @@ func ReadFrame(buf io.Reader, maxPayloadLen int) (*Frame, error) {
 	switch payloadLen {
 	case 126:
 		// Payload length is represented in the next 2 bytes (16-bit unsigned integer)
-		var l uint16
-		if err := binary.Read(buf, binary.BigEndian, &l); err != nil {
+		// Note: no length check here because we already know bufLen >= 2
+		if _, err := io.ReadFull(src, buf[:2]); err != nil {
 			return nil, fmt.Errorf("error reading 2-byte extended payload length: %w", err)
 		}
-		payloadLen = uint64(l)
+		payloadLen = uint64(binary.BigEndian.Uint16(buf[:2]))
 	case 127:
 		// Payload length is represented in the next 8 bytes (64-bit unsigned integer)
-		if err := binary.Read(buf, binary.BigEndian, &payloadLen); err != nil {
+		if bufLen < 8 {
+			return nil, fmt.Errorf("buffer too small for 8-byte extended payload length")
+		}
+		if _, err := io.ReadFull(src, buf[:8]); err != nil {
 			return nil, fmt.Errorf("error reading 8-byte extended payload length: %w", err)
 		}
+		payloadLen = binary.BigEndian.Uint64(buf[:8])
 	}
 
-	if payloadLen > uint64(maxPayloadLen) {
+	if payloadLen > uint64(maxPayloadSize) {
 		return nil, ErrFrameTooLarge
 	}
 
+	payloadOffset := uint64(0)
+
 	// read mask key (if present)
-	var mask []byte
 	if masked {
-		mask = make([]byte, 4)
-		if _, err := io.ReadFull(buf, mask); err != nil {
-			return nil, fmt.Errorf("error reading mask key: %w", err)
+		if (frameMaskingKeySize + payloadLen) > uint64(bufLen) {
+			return nil, fmt.Errorf("buffer too small to read masking key and payload")
 		}
+		if _, err := io.ReadFull(src, buf[:frameMaskingKeySize]); err != nil {
+			return nil, fmt.Errorf("error reading masking key: %w", err)
+		}
+		payloadOffset += frameMaskingKeySize
 	}
 
 	// read & optionally unmask payload
-	payload := make([]byte, payloadLen)
-	if _, err := io.ReadFull(buf, payload); err != nil {
+	payload := buf[payloadOffset : payloadOffset+payloadLen]
+	if _, err := io.ReadFull(src, payload); err != nil {
 		return nil, fmt.Errorf("error reading %d byte payload: %w", payloadLen, err)
 	}
 	if masked {
 		for i, b := range payload {
-			payload[i] = b ^ mask[i%4]
+			payload[i] = b ^ buf[:frameMaskingKeySize][i%4]
 		}
 	}
 

--- a/proto.go
+++ b/proto.go
@@ -109,11 +109,12 @@ func (m Message) String() string {
 }
 
 func truncatedPayload(p []byte, limit int) string {
-	if len(p) < limit {
-		return string(p)
-	}
-	suffix := fmt.Sprintf(" ... [%d bytes truncated]", len(p)-limit)
-	return string(p[:limit]) + suffix
+	return fmt.Sprintf("[%d bytes]", len(p))
+	// if len(p) < limit {
+	// 	return string(p)
+	// }
+	// suffix := fmt.Sprintf(" ... [%d bytes truncated]", len(p)-limit)
+	// return string(p[:limit]) + suffix
 }
 
 const (

--- a/proto_test.go
+++ b/proto_test.go
@@ -19,11 +19,12 @@ func TestFrameRoundTrip(t *testing.T) {
 		Fin:     true,
 		Payload: []byte("hello"),
 	}
-	buf := &bytes.Buffer{}
-	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, makeMaskingKey()))
+	clientBuf := &bytes.Buffer{}
+	assert.NilError(t, websocket.WriteFrameMasked(clientBuf, clientFrame, makeMaskingKey()))
 
 	// read "server" frame from buffer.
-	serverFrame, err := websocket.ReadFrame(buf, len(clientFrame.Payload))
+	serverBuf := make([]byte, 4096)
+	serverFrame, err := websocket.ReadFrame(clientBuf, serverBuf, len(clientFrame.Payload))
 	assert.NilError(t, err)
 
 	// ensure client and server frame match
@@ -47,7 +48,8 @@ func TestMaxFrameSize(t *testing.T) {
 	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, makeMaskingKey()))
 
 	// read "server" frame from buffer.
-	serverFrame, err := websocket.ReadFrame(buf, len(clientFrame.Payload)-1)
+	serverBuf := make([]byte, 4096)
+	serverFrame, err := websocket.ReadFrame(buf, serverBuf, len(clientFrame.Payload)-1)
 	assert.Error(t, err, websocket.ErrFrameTooLarge)
 	assert.Equal(t, serverFrame, nil, "expected nil frame on error")
 }

--- a/websocket.go
+++ b/websocket.go
@@ -155,7 +155,8 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 			ws.resetReadDeadline()
 		}
 
-		frame, err := ReadFrame(ws.conn, ws.maxFrameSize)
+		frameBuf := make([]byte, ws.maxFrameSize+frameMaskingKeySize)
+		frame, err := ReadFrame(ws.conn, frameBuf, ws.maxFrameSize)
 		if err != nil {
 			code := StatusServerError
 			if errors.Is(err, io.EOF) {

--- a/websocket.go
+++ b/websocket.go
@@ -188,10 +188,10 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 			if msg == nil {
 				return nil, ws.closeOnReadError(StatusProtocolError, ErrInvalidContinuation)
 			}
-			msg.Payload = append(msg.Payload, frame.Payload...)
-			if len(msg.Payload) > ws.maxMessageSize {
-				return nil, ws.closeOnReadError(StatusTooLarge, fmt.Errorf("message size %d exceeds maximum of %d bytes", len(msg.Payload), ws.maxMessageSize))
+			if len(msg.Payload)+len(frame.Payload) > ws.maxMessageSize {
+				return nil, ws.closeOnReadError(StatusTooLarge, fmt.Errorf("message size exceeds maximum of %d bytes", ws.maxMessageSize))
 			}
+			msg.Payload = append(msg.Payload, frame.Payload...)
 		case OpcodeClose:
 			if err := ws.Close(); err != nil {
 				return nil, err

--- a/websocket_benchmark_test.go
+++ b/websocket_benchmark_test.go
@@ -48,12 +48,11 @@ func BenchmarkReadFrame(b *testing.B) {
 			src := bytes.NewReader(payloadBuf.Bytes())
 			readBuf := make([]byte, size+len(mask))
 			b.ResetTimer()
+			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				_, _ = src.Seek(0, 0)
 				_, err := websocket.ReadFrame(src, readBuf, size)
-				if err != nil {
-					b.Fatalf("unexpected error: %v", err)
-				}
+				assert.NilError(b, err)
 			}
 		})
 	}

--- a/websocket_benchmark_test.go
+++ b/websocket_benchmark_test.go
@@ -1,6 +1,7 @@
 package websocket_test
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -103,7 +104,7 @@ func BenchmarkReadMessage(b *testing.B) {
 			in:  reader,
 			out: io.Discard,
 		}
-		ws := websocket.New(conn, websocket.ClientKey(makeClientKey()), websocket.Options{
+		ws := websocket.New(conn, conn.buf(), websocket.ClientKey(makeClientKey()), websocket.Options{
 			MaxFrameSize:   frameSize,
 			MaxMessageSize: msgSize,
 			// Hooks:           newTestHooks(b),
@@ -125,6 +126,10 @@ type dummyConn struct {
 	in     io.Reader
 	out    io.Writer
 	closed atomic.Bool
+}
+
+func (c *dummyConn) buf() *bufio.ReadWriter {
+	return bufio.NewReadWriter(bufio.NewReader(c.in), bufio.NewWriter(c.out))
 }
 
 func (c *dummyConn) Read(p []byte) (int, error) {

--- a/websocket_internal_test.go
+++ b/websocket_internal_test.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"bufio"
 	"net"
 	"testing"
 
@@ -11,10 +12,11 @@ func TestDefaults(t *testing.T) {
 	t.Parallel()
 
 	var (
-		conn net.Conn
-		key  = ClientKey("test-client-key")
-		opts = Options{}
-		ws   = New(conn, key, opts)
+		conn    net.Conn
+		connBuf *bufio.ReadWriter
+		key     = ClientKey("test-client-key")
+		opts    = Options{}
+		ws      = New(conn, connBuf, key, opts)
 	)
 
 	assert.Equal(t, ws.ClientKey(), key, "incorrect client key")

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -333,7 +333,8 @@ func TestProtocolBasics(t *testing.T) {
 		}
 		assert.NilError(t, websocket.WriteFrameMasked(conn, clientFrame, makeMaskingKey()))
 		// read server frame
-		serverFrame, err := websocket.ReadFrame(conn, maxFrameSize)
+		buf := make([]byte, maxFrameSize)
+		serverFrame, err := websocket.ReadFrame(conn, buf, maxFrameSize)
 		assert.NilError(t, err)
 		// ensure we get back the same frame
 		assert.Equal(t, serverFrame.Fin, clientFrame.Fin, "expected matching FIN bits")
@@ -431,7 +432,8 @@ func validateCloseFrame(t *testing.T, r io.Reader, wantStatus websocket.StatusCo
 	//
 	// This is already enforced in validateFrame, called by ReadFrame, but we
 	// must pass in a max payload size here.
-	frame, err := websocket.ReadFrame(r, 125)
+	buf := make([]byte, 4096)
+	frame, err := websocket.ReadFrame(r, buf, 125)
 	assert.NilError(t, err)
 	assert.Equal(t, frame.Opcode, websocket.OpcodeClose, "expected close frame")
 


### PR DESCRIPTION
Not particularly happy with the specific implementation here, but want to figure out what this kind of change does to allocations.  Ultimately, would like to enable using a sync.Pool of buffers when reading frames and messages from the wire, but I'm not sure what the API should look like.