### PR TITLE
fix: enforce max frame size in ReadFrame

### DIFF
--- a/proto_test.go
+++ b/proto_test.go
@@ -19,9 +19,8 @@ func TestFrameRoundTrip(t *testing.T) {
 		Fin:     true,
 		Payload: []byte("hello"),
 	}
-	mask := [4]byte{1, 2, 3, 4}
 	buf := &bytes.Buffer{}
-	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, mask))
+	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, makeMaskingKey()))
 
 	// read "server" frame from buffer.
 	serverFrame, err := websocket.ReadFrame(buf, len(clientFrame.Payload))
@@ -44,9 +43,8 @@ func TestMaxFrameSize(t *testing.T) {
 		Fin:     true,
 		Payload: []byte("hello"),
 	}
-	mask := [4]byte{1, 2, 3, 4}
 	buf := &bytes.Buffer{}
-	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, mask))
+	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, makeMaskingKey()))
 
 	// read "server" frame from buffer.
 	serverFrame, err := websocket.ReadFrame(buf, len(clientFrame.Payload)-1)

--- a/proto_test.go
+++ b/proto_test.go
@@ -23,8 +23,8 @@ func TestFrameRoundTrip(t *testing.T) {
 	buf := &bytes.Buffer{}
 	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, mask))
 
-	// read "server" frame from buffer
-	serverFrame, err := websocket.ReadFrame(buf)
+	// read "server" frame from buffer.
+	serverFrame, err := websocket.ReadFrame(buf, len(clientFrame.Payload))
 	assert.NilError(t, err)
 
 	// ensure client and server frame match

--- a/proto_test.go
+++ b/proto_test.go
@@ -32,3 +32,24 @@ func TestFrameRoundTrip(t *testing.T) {
 	assert.Equal(t, serverFrame.Opcode, clientFrame.Opcode, "expected matching opcodes")
 	assert.Equal(t, string(serverFrame.Payload), string(clientFrame.Payload), "expected matching payloads")
 }
+
+func TestMaxFrameSize(t *testing.T) {
+	// Basic test to ensure that we can read back the same frame that we
+	// write.
+	t.Parallel()
+
+	// write masked "client" frame to buffer
+	clientFrame := &websocket.Frame{
+		Opcode:  websocket.OpcodeText,
+		Fin:     true,
+		Payload: []byte("hello"),
+	}
+	mask := [4]byte{1, 2, 3, 4}
+	buf := &bytes.Buffer{}
+	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, mask))
+
+	// read "server" frame from buffer.
+	serverFrame, err := websocket.ReadFrame(buf, len(clientFrame.Payload)-1)
+	assert.Error(t, err, websocket.ErrFrameTooLarge)
+	assert.Equal(t, serverFrame, nil, "expected nil frame on error")
+}

--- a/websocket.go
+++ b/websocket.go
@@ -155,7 +155,7 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 			ws.resetReadDeadline()
 		}
 
-		frame, err := ReadFrame(ws.conn)
+		frame, err := ReadFrame(ws.conn, ws.maxFragmentSize)
 		if err != nil {
 			code := StatusServerError
 			if errors.Is(err, io.EOF) {

--- a/websocket_benchmark_test.go
+++ b/websocket_benchmark_test.go
@@ -48,7 +48,7 @@ func BenchmarkReadFrame(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_, _ = src.Seek(0, 0)
-				_, err := websocket.ReadFrame(src)
+				_, err := websocket.ReadFrame(src, size)
 				if err != nil {
 					b.Fatalf("unexpected error: %v", err)
 				}


### PR DESCRIPTION
We have a current potential security/DoS issue where we will gladly allocate a slice for an attacker-controlled payload size.

This addresses https://github.com/mccutchen/websocket/security/code-scanning/1