### PR TITLE
feat: enable autobahn tests against external test server

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -70,6 +70,10 @@ jobs:
           go-version: "stable"
 
       - uses: actions/checkout@v4
+        with:
+          # need to fetch all history to check out arbitrary commits for
+          # baseline benchmarks (if neceesssary)
+          fetch-depth: 0
 
       - name: restore previous baseline results
         id: baseline-restore

--- a/examples/benchserver/main.go
+++ b/examples/benchserver/main.go
@@ -148,5 +148,5 @@ func getListenAddr() string {
 	if port := os.Getenv("PORT"); port != "" {
 		return ":" + port
 	}
-	return "127.0.0.1:8080"
+	return "127.0.0.1:9001"
 }

--- a/websocket.go
+++ b/websocket.go
@@ -304,3 +304,8 @@ func (ws *Websocket) resetWriteDeadline() {
 		panic(fmt.Sprintf("websocket: failed to set write deadline: %s", err))
 	}
 }
+
+// ClientKey returns the client key for a connection.
+func (ws *Websocket) ClientKey() ClientKey {
+	return ws.clientKey
+}

--- a/websocket_internal_test.go
+++ b/websocket_internal_test.go
@@ -11,22 +11,23 @@ func TestDefaults(t *testing.T) {
 	t.Parallel()
 
 	var (
-		wrapedConn net.Conn
-		key        = ClientKey("test-client-key")
-		opts       = Options{}
-		conn       = New(wrapedConn, key, opts)
+		conn net.Conn
+		key  = ClientKey("test-client-key")
+		opts = Options{}
+		ws   = New(conn, key, opts)
 	)
 
-	assert.Equal(t, conn.maxFragmentSize, DefaultMaxFragmentSize, "incorrect max fragment size")
-	assert.Equal(t, conn.maxMessageSize, DefaultMaxMessageSize, "incorrect max message size")
-	assert.Equal(t, conn.readTimeout, 0, "incorrect read timeout")
-	assert.Equal(t, conn.writeTimeout, 0, "incorrect write timeout")
-	assert.Equal(t, conn.server, true, "incorrect server value")
-	assert.Equal(t, conn.hooks.OnClose != nil, true, "OnClose hook is nil")
-	assert.Equal(t, conn.hooks.OnReadError != nil, true, "OnReadError hook is nil")
-	assert.Equal(t, conn.hooks.OnReadFrame != nil, true, "OnReadFrame hook is nil")
-	assert.Equal(t, conn.hooks.OnReadMessage != nil, true, "OnReadMessage hook is nil")
-	assert.Equal(t, conn.hooks.OnWriteError != nil, true, "OnWriteError hook is nil")
-	assert.Equal(t, conn.hooks.OnWriteFrame != nil, true, "OnWriteFrame hook is nil")
-	assert.Equal(t, conn.hooks.OnWriteMessage != nil, true, "OnWriteMessage hook is nil")
+	assert.Equal(t, ws.ClientKey(), key, "incorrect client key")
+	assert.Equal(t, ws.maxFragmentSize, DefaultMaxFragmentSize, "incorrect max fragment size")
+	assert.Equal(t, ws.maxMessageSize, DefaultMaxMessageSize, "incorrect max message size")
+	assert.Equal(t, ws.readTimeout, 0, "incorrect read timeout")
+	assert.Equal(t, ws.writeTimeout, 0, "incorrect write timeout")
+	assert.Equal(t, ws.server, true, "incorrect server value")
+	assert.Equal(t, ws.hooks.OnClose != nil, true, "OnClose hook is nil")
+	assert.Equal(t, ws.hooks.OnReadError != nil, true, "OnReadError hook is nil")
+	assert.Equal(t, ws.hooks.OnReadFrame != nil, true, "OnReadFrame hook is nil")
+	assert.Equal(t, ws.hooks.OnReadMessage != nil, true, "OnReadMessage hook is nil")
+	assert.Equal(t, ws.hooks.OnWriteError != nil, true, "OnWriteError hook is nil")
+	assert.Equal(t, ws.hooks.OnWriteFrame != nil, true, "OnWriteFrame hook is nil")
+	assert.Equal(t, ws.hooks.OnWriteMessage != nil, true, "OnWriteMessage hook is nil")
 }


### PR DESCRIPTION
The idea here is that there are some test cases (e.g. in the 9.* suite that send extremely large frames/messages) where our implementation appears to be painfully slow, so being able to run specific autobahn tests against an external server like

```bash
make testautobahn AUTOBAHN_CASES=9.2.6 AUTOBAHN_TARGET=localhost:8080
```

will hopefully make it easier to gain visibility into performance issues.  (See also #23 for one potential path towards optimization.)