### PR TITLE
ci: run benchmarks on demand

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -3,25 +3,21 @@ name: bench
 on:
   workflow_dispatch:
     inputs:
+      pr_number:
+        description: 'pull request number to benchmark'
+        required: true
+        type: number
       baseline_sha:
-        description: 'Baseline commit (defaults to latest main)'
+        description: 'baseline commit (defaults to latest main)'
         required: false
         type: string
         default: ''
-      comparison_sha:
-        description: 'Commit to compare against baseline'
-        required: true
-        type: string
-      pr_number:
-        description: 'Pull request on which to post benchmark results (optional)'
-        required: false
-        type: number
 
 jobs:
   baseline:
     runs-on: ubuntu-latest
     outputs:
-      baseline_sha: ${{ steps.get-baseline.outputs.baseline_sha }}
+      baseline_sha: ${{ steps.get-baseline.outputs.baseline }}
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -40,11 +36,11 @@ jobs:
           else
             BASELINE="${{ inputs.baseline_sha }}"
           fi
-          echo "baseline_sha=${BASELINE::7}" >> $GITHUB_OUTPUT
+          echo "baseline=${BASELINE::7}" >> $GITHUB_OUTPUT
 
       - name: run baseline benchmarks
         run: |
-          git checkout ${{ steps.get-baseline.outputs.baseline_sha }}
+          git checkout ${{ steps.get-baseline.outputs.baseline }}
           make bench | tee bench-results.txt $GITHUB_STEP_SUMMARY
 
       - name: upload baseline results
@@ -54,8 +50,10 @@ jobs:
           path: bench-results.txt
           retention-days: 1
 
-  comparison:
+  head:
     runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.get-head.outputs.head }}
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -65,20 +63,34 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: run comparison benchmarks
+      - name: get pr head commit
+        id: get-head
         run: |
-          git checkout ${{ inputs.comparison_sha }}
+          # Use GitHub API to get PR details
+          PR_DATA=$(curl -s -H "Authorization: token ${{ github.token }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ inputs.pr_number }}")
+
+          HEAD_SHA=$(echo "$PR_DATA" | jq -r .head.sha)
+          if [ "$HEAD_SHA" = "null" ]; then
+            echo "Failed to get PR head commit"
+            exit 1
+          fi
+          echo "head=${HEAD_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: run head benchmarks
+        run: |
+          git checkout ${{ steps.get-head.outputs.head }}
           make bench | tee bench-results.txt $GITHUB_STEP_SUMMARY
 
-      - name: upload comparison results
+      - name: upload head results
         uses: actions/upload-artifact@v4
         with:
-          name: comparison-results
+          name: head-results
           path: bench-results.txt
           retention-days: 1
 
   analysis:
-    needs: [baseline, comparison]
+    needs: [baseline, head]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -90,45 +102,41 @@ jobs:
           name: baseline-results
           path: ./baseline
 
-      - name: download comparison results
+      - name: download head results
         uses: actions/download-artifact@v4
         with:
-          name: comparison-results
-          path: ./comparison
+          name: head-results
+          path: ./head
 
-      - uses: actions/setup-go@v5
+      - name: install go
+        uses: actions/setup-go@v5
         with:
           go-version: "stable"
 
-      - name: analyze results
+      - name: compare results with benchstat
         run: |
           set -euo pipefail
 
-          BASELINE_SHA="${{ needs.baseline.outputs.baseline_sha }}"
-          COMPARISON_SHA="${{ inputs.comparison_sha }}"
-          COMPARISON_SHA="${COMPARISON_SHA::7}"
-          COMPARISON_URL="https://github.com/${{ github.repository }}/compare/$BASELINE...$COMPARISON"
-          COMPARISON_LINK="[$BASELINE...$COMPARISON]($COMPARISON_URL)"
+          BASELINE="${{ needs.baseline.outputs.baseline_sha }}"
+          HEAD="${{ needs.head.outputs.head_sha }}"
+          COMPARE_URL="https://github.com/${{ github.repository }}/compare/$BASELINE...$HEAD"
+          COMPARE_LINK="[$BASELINE...$HEAD]($COMPARE_URL)"
           SUMMARY_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          go run golang.org/x/perf/cmd/benchstat@latest ./baseline/bench-results.txt ./comparison/bench-results.txt | tee bench-stats.txt
-
-          # Create both GitHub step summary and PR comment content
-          cat <<EOF >pr_comment
-          ### benchstats: $COMPARISON_LINK
+          cat <<EOF > pr_comment
+          ### benchstats: $COMPARE_LINK
 
           View full benchmark output on the [workflow summary]($SUMMARY_URL).
 
           \`\`\`
-          $(cat bench-stats.txt)
+          $(go run golang.org/x/perf/cmd/benchstat@latest ./baseline/bench-results.txt ./head/bench-results.txt)
           \`\`\`
           EOF
 
           cat pr_comment >> $GITHUB_STEP_SUMMARY
 
-      - name: post benchmark summary
+      - name: post benchmark results
         uses: marocchino/sticky-pull-request-comment@v2
-        if: inputs.pr_number
         with:
           path: pr_comment
           number: ${{ inputs.pr_number }}

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
         default: ''
-      comparison_commit:
+      comparison_sha:
         description: 'Commit to compare against baseline'
         required: true
         type: string
@@ -67,7 +67,7 @@ jobs:
 
       - name: run comparison benchmarks
         run: |
-          git checkout ${{ inputs.comparison_commit }}
+          git checkout ${{ inputs.comparison_sha }}
           make bench | tee bench-results.txt $GITHUB_STEP_SUMMARY
 
       - name: upload comparison results
@@ -105,7 +105,7 @@ jobs:
           set -euo pipefail
 
           BASELINE_SHA="${{ needs.baseline.outputs.baseline_sha }}"
-          COMPARISON_SHA="${{ inputs.comparison_commit }}"
+          COMPARISON_SHA="${{ inputs.comparison_sha }}"
           COMPARISON_SHA="${COMPARISON_SHA::7}"
           COMPARISON_URL="https://github.com/${{ github.repository }}/compare/$BASELINE...$COMPARISON"
           COMPARISON_LINK="[$BASELINE...$COMPARISON]($COMPARISON_URL)"

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,5 +1,3 @@
-# Adapted from:
-# https://github.com/swaggest/rest/blob/b19db8242abe420b23ea8ece43dd2fb79056a943/.github/workflows/bench.yml
 name: bench
 
 on:
@@ -19,140 +17,118 @@ on:
         required: false
         type: number
 
-# cancel CI runs when a new commit is pushed to any branch except main
-concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
-env:
-  BASELINE_RESULTS_FILE: bench-results-main.txt
-  BASELINE_COMMIT_FILE: bench-commit-main.txt
-
 jobs:
   baseline:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
+    outputs:
+      baseline_sha: ${{ steps.get-baseline.outputs.baseline_sha }}
     steps:
       - uses: actions/setup-go@v5
         with:
           go-version: "stable"
 
       - uses: actions/checkout@v4
-
-      - name: cache previous baseline results
-        uses: actions/cache@v4
         with:
-          path: |
-            bench-*.txt
-          key: ${{ runner.os }}-bench-results-${{ hashFiles('websocket_benchmark_test.go') }}
-          restore-keys: |
-            ${{ runner.os }}-bench-results-
+          fetch-depth: 0
 
-      - name: run benchmarks
+      - name: determine baseline commit
+        id: get-baseline
         run: |
-          set -euo pipefail
+          if [ -z "${{ inputs.baseline_sha }}" ]; then
+            git fetch origin main
+            BASELINE=$(git rev-parse origin/main)
+          else
+            BASELINE="${{ inputs.baseline_sha }}"
+          fi
+          echo "baseline_sha=${BASELINE::7}" >> $GITHUB_OUTPUT
 
-          COMMIT="${GITHUB_SHA::7}"
-          COMMIT_URL="https://github.com/mccutchen/websocket/commit/$COMMIT"
-          COMMIT_LINK="[$COMMIT]($COMMIT_URL)"
+      - name: run baseline benchmarks
+        run: |
+          git checkout ${{ steps.get-baseline.outputs.baseline_sha }}
+          make bench | tee bench-results.txt $GITHUB_STEP_SUMMARY
 
-          echo -n "$COMMIT" > $BASELINE_COMMIT_FILE
-          make bench | tee $BASELINE_RESULTS_FILE
+      - name: upload baseline results
+        uses: actions/upload-artifact@v4
+        with:
+          name: baseline-results
+          path: bench-results.txt
+          retention-days: 1
 
-          cat <<EOF >>$GITHUB_STEP_SUMMARY
-          ### benchmark results @ $COMMIT_LINK
-          \`\`\`
-          $(cat $BASELINE_RESULTS_FILE)
-          \`\`\`
-          EOF
-
-  pr:
+  comparison:
     runs-on: ubuntu-latest
-    if: ${{ github.ref != 'refs/heads/main' }}
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
 
-    # allow commenting on PR:
-    # https://github.com/marocchino/sticky-pull-request-comment/blob/main/README.md#error-resource-not-accessible-by-integration
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: run comparison benchmarks
+        run: |
+          git checkout ${{ inputs.comparison_commit }}
+          make bench | tee bench-results.txt $GITHUB_STEP_SUMMARY
+
+      - name: upload comparison results
+        uses: actions/upload-artifact@v4
+        with:
+          name: comparison-results
+          path: bench-results.txt
+          retention-days: 1
+
+  analysis:
+    needs: [baseline, comparison]
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
 
     steps:
+      - name: download baseline results
+        uses: actions/download-artifact@v4
+        with:
+          name: baseline-results
+          path: ./baseline
+
+      - name: download comparison results
+        uses: actions/download-artifact@v4
+        with:
+          name: comparison-results
+          path: ./comparison
+
       - uses: actions/setup-go@v5
         with:
           go-version: "stable"
 
-      - uses: actions/checkout@v4
-        with:
-          # need to fetch all history to check out arbitrary commits for
-          # baseline benchmarks (if neceesssary)
-          fetch-depth: 0
-
-      - name: restore previous baseline results
-        id: baseline-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            bench-*.txt
-          key: ${{ runner.os }}-bench-results-${{ hashFiles('websocket_benchmark_test.go') }}
-          restore-keys: |
-            ${{ runner.os }}-bench-results-
-
-      - name: benchmark current commit
+      - name: analyze results
         run: |
           set -euo pipefail
 
-          COMMIT="${{ github.event.pull_request.head.sha }}"
-          COMMIT="${COMMIT::7}"
-          COMMIT_URL="https://github.com/mccutchen/websocket/commit/$COMMIT"
-          COMMIT_LINK="[$COMMIT]($COMMIT_URL)"
-
-          make bench | tee bench-commit-$COMMIT.txt
-
-          cat <<EOF >>$GITHUB_STEP_SUMMARY
-          ### benchmark results @ $COMMIT_LINK
-          \`\`\`
-          $(cat bench-commit-$COMMIT.txt)
-          \`\`\`
-          EOF
-
-      - name: benchmark prev commit if necessary
-        if: ${{ steps.baseline-restore.outputs.cache-hit == '' }}
-        run: |
-          set -euo pipefail
-
-          BASE_SHA=${{ github.event.pull_request.base.sha }}
-          BASE_SHA="${BASE_SHA::7}"
-          echo $BASE_SHA > $BASELINE_COMMIT_FILE
-
-          git fetch origin main $BASE_SHA
-          git reset --hard $BASE_SHA
-          make bench | tee $BASELINE_RESULTS_FILE
-          git reset --hard $GITHUB_SHA
-
-      # TODO: cache benchstat binary
-      - name: compare results with benchstat
-        run: |
-          set -euo pipefail
-
-          COMMIT="${{ github.event.pull_request.head.sha }}"
-          COMMIT="${COMMIT::7}"
-          PREV_COMMIT="$(cat $BASELINE_COMMIT_FILE 2>/dev/null)"
-          COMPARE_URL="https://github.com/mccutchen/websocket/compare/$PREV_COMMIT...$COMMIT"
-          COMPARE_LINK="[$PREV_COMMIT...$COMMIT]($COMPARE_URL)"
+          BASELINE_SHA="${{ needs.baseline.outputs.baseline_sha }}"
+          COMPARISON_SHA="${{ inputs.comparison_commit }}"
+          COMPARISON_SHA="${COMPARISON_SHA::7}"
+          COMPARISON_URL="https://github.com/${{ github.repository }}/compare/$BASELINE...$COMPARISON"
+          COMPARISON_LINK="[$BASELINE...$COMPARISON]($COMPARISON_URL)"
           SUMMARY_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          go run golang.org/x/perf/cmd/benchstat@latest $BASELINE_RESULTS_FILE bench-commit-$COMMIT.txt | tee -a bench-stats.txt
+          go run golang.org/x/perf/cmd/benchstat@latest ./baseline/bench-results.txt ./comparison/bench-results.txt | tee bench-stats.txt
 
+          # Create both GitHub step summary and PR comment content
           cat <<EOF >pr_comment
-          ### benchstats: $COMPARE_LINK
+          ### benchstats: $COMPARISON_LINK
 
-          View full benchmark output for $COMMIT on the [workflow summary]($SUMMARY_URL).
+          View full benchmark output on the [workflow summary]($SUMMARY_URL).
 
           \`\`\`
           $(cat bench-stats.txt)
           \`\`\`
           EOF
 
-      - name: post benchmark results
+          cat pr_comment >> $GITHUB_STEP_SUMMARY
+
+      - name: post benchmark summary
         uses: marocchino/sticky-pull-request-comment@v2
+        if: inputs.pr_number
         with:
           path: pr_comment
+          number: ${{ inputs.pr_number }}

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -13,6 +13,11 @@ on:
         type: string
         default: ''
 
+# cancel when a new worfkflow is dispatched
+concurrency:
+  group: "${{ github.workflow }}-${{ inputs.pr_number }}"
+  cancel-in-progress: true
+
 jobs:
   baseline:
     runs-on: ubuntu-latest

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -1,0 +1,51 @@
+name: pr
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  bench-instructions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: compose benchmark instructions
+        run: |
+          set -euo pipefail
+
+          # Create a URL-encoded dispatch URL that will pre-fill the parameters
+          REPO="${{ github.repository }}"
+          WORKFLOW_ID="bench"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          # Create the workflow dispatch URL
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          DISPATCH_URL="https://github.com/${REPO}/actions/workflows/${WORKFLOW_ID}/dispatch"
+
+          # Create markdown for the manual trigger button with PR number included
+          BUTTON="[![Run Benchmarks](https://img.shields.io/badge/Run-Benchmarks-blue)](${DISPATCH_URL}?user=${USER}&ref=main&inputs=%7B%22compare_commit%22%3A%22${HEAD_SHA}%22%2C%22pr_number%22%3A%22${PR_NUMBER}%22%7D)"
+
+          # Create the full comment
+          cat <<EOF > pr_comment
+          ### 🏃 Run Benchmarks
+
+          Click here to run benchmarks comparing this PR against main:
+          ${BUTTON}
+
+          Or run manually with:
+          \`\`\`bash
+          gh workflow run $WORKFLOW_ID.yaml -f compare_commit=${HEAD_SHA::7} -f pr_number=${PR_NUMBER}
+          \`\`\`
+
+          You can also compare against a specific baseline commit:
+          \`\`\`bash
+          gh workflow run $WORKFLOW_ID.yaml -f compare_commit=${HEAD_SHA::7} -f pr_number=${PR_NUMBER} -f baseline_commit=<commit-sha>
+          \`\`\`
+          EOF
+
+      - name: post benchmark instructions
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: pr_comment

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -25,21 +25,13 @@ jobs:
 
           # Create the full comment
           cat <<EOF > pr_comment
-          ### 🏃 Run Benchmarks
-
-          Run benchmarks comparing $HEAD_SHA from this PR against \`main\`:
+          🔥 Run benchmarks comparing $HEAD_SHA against \`main\`:
           \`\`\`bash
           gh workflow run $WORKFLOW_ID.yaml -f comparison_sha=${HEAD_SHA::7} -f pr_number=${PR_NUMBER}
           \`\`\`
 
-          <details>
-          <summary>You can also compare against a specific baseline commit:</summary>
+          _Note: this comment will update with each new commit._
 
-          \`\`\`bash
-          gh workflow run $WORKFLOW_ID.yaml -f comparison_sha=${HEAD_SHA::7} -f pr_number=${PR_NUMBER} -f baseline_sha=BASELINE_SHA
-          \`\`\`
-
-          </details>
           EOF
 
       - name: post benchmark instructions

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -22,27 +22,22 @@ jobs:
 
           # Create the workflow dispatch URL
           PR_NUMBER="${{ github.event.pull_request.number }}"
-          DISPATCH_URL="https://github.com/${REPO}/actions/workflows/${WORKFLOW_ID}/dispatch"
-
-          # Create markdown for the manual trigger button with PR number included
-          BUTTON="[![Run Benchmarks](https://img.shields.io/badge/Run-Benchmarks-blue)](${DISPATCH_URL}?user=${USER}&ref=main&inputs=%7B%22compare_commit%22%3A%22${HEAD_SHA}%22%2C%22pr_number%22%3A%22${PR_NUMBER}%22%7D)"
 
           # Create the full comment
           cat <<EOF > pr_comment
           ### 🏃 Run Benchmarks
 
-          Click here to run benchmarks comparing this PR against main:
-          ${BUTTON}
-
-          Or run manually with:
+          Run benchmarks comparing $HEAD_SHA from this PR against \`main\`:
           \`\`\`bash
-          gh workflow run $WORKFLOW_ID.yaml -f compare_commit=${HEAD_SHA::7} -f pr_number=${PR_NUMBER}
+          gh workflow run $WORKFLOW_ID.yaml -f comparison_commit=${HEAD_SHA::7} -f pr_number=${PR_NUMBER}
           \`\`\`
 
-          You can also compare against a specific baseline commit:
+          <details>
+          <summary>You can also compare against a specific baseline commit:</summary>
           \`\`\`bash
-          gh workflow run $WORKFLOW_ID.yaml -f compare_commit=${HEAD_SHA::7} -f pr_number=${PR_NUMBER} -f baseline_commit=<commit-sha>
+          gh workflow run $WORKFLOW_ID.yaml -f comparison_commit=${HEAD_SHA::7} -f pr_number=${PR_NUMBER} -f baseline_commit=BASELINE_SHA
           \`\`\`
+          </details>
           EOF
 
       - name: post benchmark instructions

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -34,9 +34,11 @@ jobs:
 
           <details>
           <summary>You can also compare against a specific baseline commit:</summary>
+
           \`\`\`bash
           gh workflow run $WORKFLOW_ID.yaml -f comparison_sha=${HEAD_SHA::7} -f pr_number=${PR_NUMBER} -f baseline_sha=BASELINE_SHA
           \`\`\`
+
           </details>
           EOF
 

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -29,13 +29,13 @@ jobs:
 
           Run benchmarks comparing $HEAD_SHA from this PR against \`main\`:
           \`\`\`bash
-          gh workflow run $WORKFLOW_ID.yaml -f comparison_commit=${HEAD_SHA::7} -f pr_number=${PR_NUMBER}
+          gh workflow run $WORKFLOW_ID.yaml -f comparison_sha=${HEAD_SHA::7} -f pr_number=${PR_NUMBER}
           \`\`\`
 
           <details>
           <summary>You can also compare against a specific baseline commit:</summary>
           \`\`\`bash
-          gh workflow run $WORKFLOW_ID.yaml -f comparison_commit=${HEAD_SHA::7} -f pr_number=${PR_NUMBER} -f baseline_commit=BASELINE_SHA
+          gh workflow run $WORKFLOW_ID.yaml -f comparison_sha=${HEAD_SHA::7} -f pr_number=${PR_NUMBER} -f baseline_sha=BASELINE_SHA
           \`\`\`
           </details>
           EOF


### PR DESCRIPTION
The [bench workflow](https://github.com/mccutchen/websocket/actions/workflows/bench.yaml) is both very slow (~4 minutes per run) and flaky (see [example failure](https://github.com/mccutchen/websocket/actions/runs/12901137705/job/35972729251) getting in the way of #25).

Here we attempt to transform it into an on-demand workflow, made easier by an automated comment with instructions for kicking it off.  The initial transformation was made primarily by copy/pasting the old workflow into [claude](https://claude.ai)[^1] and following up with some minor cosmetic tweaks.

Let's see what happens, I guess?

[^1]: Er, TIL that you can't share conversations from claude dot ai??