### PR TITLE
ci: switch bench worfklow trigger in prep for rewrite

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -3,10 +3,21 @@
 name: bench
 
 on:
-  push:
-    branches: [main] # on pushes TO main
-  pull_request:
-    branches: [main] # on pull requests AGAINST main
+  workflow_dispatch:
+    inputs:
+      baseline_sha:
+        description: 'Baseline commit (defaults to latest main)'
+        required: false
+        type: string
+        default: ''
+      comparison_commit:
+        description: 'Commit to compare against baseline'
+        required: true
+        type: string
+      pr_number:
+        description: 'Pull request on which to post benchmark results (optional)'
+        required: false
+        type: number
 
 # cancel CI runs when a new commit is pushed to any branch except main
 concurrency:


### PR DESCRIPTION
Apparently workflow_dispatch jobs are only recognized in the main branch, which is probably critical for security, but that prevents us from testing the rewrite of the bench action in https://github.com/mccutchen/websocket/pull/26.

See [that PR](https://github.com/mccutchen/websocket/pull/26) for details about where this is going.

Note: this will temporarily disable the bench action.