### PR TITLE
ci: fix benchmark comments

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -143,5 +143,6 @@ jobs:
       - name: post benchmark results
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: results
           path: pr_comment
           number: ${{ inputs.pr_number }}

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -46,7 +46,13 @@ jobs:
       - name: run baseline benchmarks
         run: |
           git checkout ${{ steps.get-baseline.outputs.baseline }}
-          make bench | tee bench-results.txt $GITHUB_STEP_SUMMARY
+          make bench | tee bench-results.txt
+          cat <<EOF >> $GITHUB_STEP_SUMMARY
+          ### baseline benchmarks (${{ steps.get-baseline.outputs.baseline }})
+          \`\`\`
+          $(cat bench-results.txt)
+          \`\`\`
+          EOF
 
       - name: upload baseline results
         uses: actions/upload-artifact@v4
@@ -85,7 +91,13 @@ jobs:
       - name: run head benchmarks
         run: |
           git checkout ${{ steps.get-head.outputs.head }}
-          make bench | tee bench-results.txt $GITHUB_STEP_SUMMARY
+          make bench | tee bench-results.txt
+          cat <<EOF >> $GITHUB_STEP_SUMMARY
+          ### HEAD benchmarks (${{ steps.get-head.outputs.head }})
+          \`\`\`
+          $(cat bench-results.txt)
+          \`\`\`
+          EOF
 
       - name: upload head results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -27,7 +27,7 @@ jobs:
           cat <<EOF > pr_comment
           🔥 Run benchmarks comparing $HEAD_SHA against \`main\`:
           \`\`\`bash
-          gh workflow run $WORKFLOW_ID.yaml -f comparison_sha=${HEAD_SHA::7} -f pr_number=${PR_NUMBER}
+          gh workflow run $WORKFLOW_ID.yaml -f pr_number=${PR_NUMBER}
           \`\`\`
 
           _Note: this comment will update with each new commit._
@@ -37,4 +37,5 @@ jobs:
       - name: post benchmark instructions
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: instructions
           path: pr_comment


### PR DESCRIPTION
As discovered in https://github.com/mccutchen/websocket/pull/26#issuecomment-2606335230, AFAICT changes to the benchmark workflow can't be tested till they're merged into master, due to restrictions on the `workflow_dispatch` event.

Here we make a couple of fixes and hope they work!