### PR TITLE
refactor: use buffered connections for I/O

### DIFF
--- a/websocket_benchmark_test.go
+++ b/websocket_benchmark_test.go
@@ -1,6 +1,7 @@
 package websocket_test
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -94,7 +95,7 @@ func BenchmarkReadMessage(b *testing.B) {
 			in:  reader,
 			out: io.Discard,
 		}
-		ws := websocket.New(conn, websocket.NewClientKey(), websocket.ServerMode, websocket.Options{
+		ws := websocket.New(conn, conn.buf(), websocket.NewClientKey(), websocket.ServerMode, websocket.Options{
 			MaxFrameSize:   frameSize,
 			MaxMessageSize: msgSize,
 			// Hooks:           newTestHooks(b),
@@ -116,6 +117,10 @@ type dummyConn struct {
 	in     io.Reader
 	out    io.Writer
 	closed atomic.Bool
+}
+
+func (c *dummyConn) buf() *bufio.ReadWriter {
+	return bufio.NewReadWriter(bufio.NewReader(c.in), bufio.NewWriter(c.out))
 }
 
 func (c *dummyConn) Read(p []byte) (int, error) {

--- a/websocket_internal_test.go
+++ b/websocket_internal_test.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"bufio"
 	"net"
 	"testing"
 
@@ -11,10 +12,11 @@ func TestDefaults(t *testing.T) {
 	t.Parallel()
 
 	var (
-		conn net.Conn
-		key  = ClientKey("test-client-key")
-		opts = Options{}
-		ws   = New(conn, key, ServerMode, opts)
+		conn    net.Conn
+		connBuf *bufio.ReadWriter
+		key     = ClientKey("test-client-key")
+		opts    = Options{}
+		ws      = New(conn, connBuf, key, ServerMode, opts)
 	)
 
 	assert.Equal(t, ws.ClientKey(), key, "incorrect client key")


### PR DESCRIPTION
Force the use of buffered I/O via [bufio.ReadWriter](https://pkg.go.dev/bufio#ReadWriter) to hopefully make reads/writes more efficient.  Extracted from #23, which may or may not pan out.