### PR TITLE
test: major overhaul of unit tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   test:
-    name: test
     runs-on: ubuntu-latest
 
     strategy:
@@ -34,7 +33,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: test
-      run: make testci
+      run: make test-ci
 
     - name: report code coverage
       uses: codecov/codecov-action@v5
@@ -42,3 +41,18 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
       if: ${{ matrix.go-version == 'stable' }}
+
+  autobahn:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: setup
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+
+    - name: checkout
+      uses: actions/checkout@v4
+
+    - name: run autobahn tests
+      run: make test-autobahn

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ test:
 # Test command to run for continuous integration, which includes code coverage
 # based on codecov.io's documentation:
 # https://github.com/codecov/example-go/blob/b85638743b972bd0bd2af63421fe513c6f968930/README.md
-testci:
+test-ci:
 	go test $(TEST_ARGS) $(COVERAGE_ARGS) ./...
 .PHONY: testci
 
-testcover: testci
+test-cover: testci
 	go tool cover -html=$(COVERAGE_PATH)
 .PHONY: testcover
 
@@ -42,9 +42,13 @@ testcover: testci
 # To run only a subset of autobahn tests, specify them in an AUTOBAHN_CASES env
 # var:
 #
-#     AUTOBAHN_CASES=5.7,6.12.* make testautobahn
-testautobahn:
-	AUTOBAHN_TESTS=1 AUTOBAHN_OPEN_REPORT=1 go test -run ^TestWebSocketServer$$ $(AUTOBAHN_ARGS) $(COVERAGE_ARGS) ./...
+#     AUTOBAHN_CASES=5.7,6.12.* make test-autobahn
+#
+# To automatically open the HTML test report, add AUTOBAHN_REPORT:
+#
+#     AUTOBAHN_REPORT=1 make test-autobahn
+test-autobahn:
+	AUTOBAHN_TESTS=1 go test -run ^TestAutobahn$$ $(AUTOBAHN_ARGS) ./...
 .PHONY: autobahntests
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # Default flags used by the test, testci, testcover targets
 COVERAGE_PATH ?= coverage.out
 COVERAGE_ARGS ?= -covermode=atomic -coverprofile=$(COVERAGE_PATH)
-TEST_ARGS     ?= -race -timeout 120s -count=1
+TEST_ARGS     ?= -race -count=1 -timeout=10s 
+AUTOBAHN_ARGS ?= -race -count=1 -timeout=120s
 BENCH_COUNT   ?= 10
 BENCH_ARGS    ?= -bench=. -benchmem -count=$(BENCH_COUNT) -run=^$$
 
@@ -11,23 +12,17 @@ CMD_REVIVE      := go run github.com/mgechev/revive@v1.5.1
 CMD_STATICCHECK := go run honnef.co/go/tools/cmd/staticcheck@2024.1.1
 
 # Find examples to build
+OUT_DIR         ?= bin
+OUT_DIR_ABS     := $(abspath $(OUT_DIR))
 EXAMPLE_DIR     := examples
 EXAMPLE_NAMES   := $(shell ls $(EXAMPLE_DIR))
-OUT_DIR         ?= bin
-OUT_PATHS       := $(addprefix $(OUT_DIR)/,$(EXAMPLE_NAMES)) # -> $(OUT_DIR)/foo $(OUT_DIR)/bar
-OUT_DIR_ABS     := $(abspath $(OUT_DIR))
+EXAMPLE_PATHS   := $(addprefix $(OUT_DIR)/,$(EXAMPLE_NAMES)) # -> $(OUT_DIR)/foo $(OUT_DIR)/bar
 
-# Build every example we found
-build: clean $(OUT_PATHS)
-.PHONY: build
 
-# Build a specific example
-$(OUT_DIR)/%: force-rebuild
-	@mkdir -p $(OUT_DIR)
-	@echo "Building $@"
-	cd $(EXAMPLE_DIR)/$* && CGO_ENABLED=0 go build $(BUILD_ARGS) -o $(abspath $(OUT_DIR))/$*
-
-test: build
+# ===========================================================================
+# Tests
+# ===========================================================================
+test:
 	go test $(TEST_ARGS) ./...
 .PHONY: test
 
@@ -35,7 +30,7 @@ test: build
 # based on codecov.io's documentation:
 # https://github.com/codecov/example-go/blob/b85638743b972bd0bd2af63421fe513c6f968930/README.md
 testci:
-	AUTOBAHN_TESTS=1 go test $(TEST_ARGS) $(COVERAGE_ARGS) ./...
+	go test $(TEST_ARGS) $(COVERAGE_ARGS) ./...
 .PHONY: testci
 
 testcover: testci
@@ -49,14 +44,21 @@ testcover: testci
 #
 #     AUTOBAHN_CASES=5.7,6.12.* make testautobahn
 testautobahn:
-	AUTOBAHN_TESTS=1 AUTOBAHN_OPEN_REPORT=1 go test -run ^TestWebSocketServer$$ $(TEST_ARGS) ./...
+	AUTOBAHN_TESTS=1 AUTOBAHN_OPEN_REPORT=1 go test -run ^TestWebSocketServer$$ $(AUTOBAHN_ARGS) $(COVERAGE_ARGS) ./...
 .PHONY: autobahntests
 
 
+# ===========================================================================
+# Benchmarks
+# ===========================================================================
 bench:
 	go test $(BENCH_ARGS)
 .PHONY: bench
 
+
+# ===========================================================================
+# Linting/formatting
+# ===========================================================================
 lint:
 	test -z "$$($(CMD_GOFUMPT) -d -e .)" || (echo "Error: gofmt failed"; $(CMD_GOFUMPT) -d -e . ; exit 1)
 	go vet ./...
@@ -68,11 +70,24 @@ fmt:
 	$(CMD_GOFUMPT) -d -e -w .
 .PHONY: fmt
 
-clean:
-	rm -rf $(OUT_DIR) $(COVERAGE_PATH)
-.PHONY: clean
 
+# ===========================================================================
+# Example binaries
+# ===========================================================================
+# Build every example we found
+examples: $(EXAMPLE_PATHS)
+.PHONY: examples
+
+# Build a specific example
+$(OUT_DIR)/%: force-rebuild
+	@mkdir -p $(OUT_DIR)
+	@echo "Building $@"
+	cd $(EXAMPLE_DIR)/$* && CGO_ENABLED=0 go build $(BUILD_ARGS) -o $(abspath $(OUT_DIR))/$*
 
 # phony target used to always rebuild the example binaries
 .PHONY: force-rebuild
 force-rebuild:
+
+clean:
+	rm -rf $(OUT_DIR) $(COVERAGE_PATH)
+.PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Default flags used by the test, testci, testcover targets
 COVERAGE_PATH ?= coverage.out
 COVERAGE_ARGS ?= -covermode=atomic -coverprofile=$(COVERAGE_PATH)
-TEST_ARGS     ?= -race -timeout 60s -count=1
+TEST_ARGS     ?= -race -timeout 120s -count=1
 BENCH_COUNT   ?= 10
 BENCH_ARGS    ?= -bench=. -benchmem -count=$(BENCH_COUNT) -run=^$$
 

--- a/internal/testing/assert/assert.go
+++ b/internal/testing/assert/assert.go
@@ -21,7 +21,7 @@ func Equal[T comparable](t testing.TB, got, want T, msg string, arg ...any) {
 			msg = "expected values to match"
 		}
 		msg = fmt.Sprintf(msg, arg...)
-		t.Fatalf("%s:\nwant: %#v\n got: %#v", msg, want, got)
+		t.Fatalf("%s:\nwant: %v\n got: %v", msg, want, got)
 	}
 }
 

--- a/proto.go
+++ b/proto.go
@@ -310,6 +310,7 @@ func messageFrames(msg *Message, frameSize int) []*Frame {
 		if fin {
 			break
 		}
+		offset += frameSize
 	}
 	return result
 }

--- a/proto.go
+++ b/proto.go
@@ -21,6 +21,7 @@ var (
 	ErrControlFrameFragmented = errors.New("control frame must not be fragmented")
 	ErrControlFrameTooLarge   = errors.New("control frame payload exceeds 125 bytes")
 	ErrFrameTooLarge          = errors.New("frame payload too large")
+	ErrMessageTooLarge        = errors.New("message paylaod too large")
 	ErrInvalidClosePayload    = errors.New("close frame payload must be at least 2 bytes")
 	ErrInvalidContinuation    = errors.New("unexpected continuation frame")
 	ErrInvalidUTF8            = errors.New("invalid UTF-8")

--- a/proto.go
+++ b/proto.go
@@ -262,16 +262,12 @@ func WriteFrameMasked(dst io.Writer, frame *Frame, mask MaskingKey) error {
 }
 
 // CloseFrame creates a close frame with an optional error message.
-func CloseFrame(code StatusCode, err error) *Frame {
+func CloseFrame(code StatusCode, reason string) *Frame {
 	var payload []byte
 	if code > 0 {
-		var errMsg []byte
-		if err != nil {
-			errMsg = []byte(err.Error())
-		}
-		payload = make([]byte, 0, 2+len(errMsg))
+		payload = make([]byte, 0, 2+len(reason))
 		payload = binary.BigEndian.AppendUint16(payload, uint16(code))
-		payload = append(payload, errMsg...)
+		payload = append(payload, []byte(reason)...)
 	}
 	return &Frame{
 		Fin:     true,

--- a/proto.go
+++ b/proto.go
@@ -25,6 +25,7 @@ var (
 	ErrInvalidClosePayload    = errors.New("close frame payload must be at least 2 bytes")
 	ErrInvalidContinuation    = errors.New("unexpected continuation frame")
 	ErrInvalidUTF8            = errors.New("invalid UTF-8")
+	ErrUnknownOpcode          = errors.New("unknown opcode")
 	ErrUnmaskedClientFrame    = errors.New("received unmasked client frame")
 	ErrUnsupportedRSVBits     = errors.New("frame has unsupported RSV bits set")
 )

--- a/proto.go
+++ b/proto.go
@@ -331,14 +331,16 @@ var reservedStatusCodes = map[uint16]bool{
 	2999: true,
 }
 
-func validateFrame(frame *Frame, maxFrameSize int, requireMask bool) error {
+func validateFrame(frame *Frame, maxFrameSize int, mode Mode) error {
 	// We do not support any extensions, per the spec all RSV bits must be 0:
 	// https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
 	if frame.RSV1 || frame.RSV2 || frame.RSV3 {
 		return ErrUnsupportedRSVBits
 	}
 
-	if requireMask && !frame.Masked {
+	// If the data is being sent by the client, the frame(s) MUST be masked
+	// https://datatracker.ietf.org/doc/html/rfc6455#section-6.1
+	if mode == ServerMode && !frame.Masked {
 		return ErrUnmaskedClientFrame
 	}
 

--- a/proto.go
+++ b/proto.go
@@ -15,8 +15,8 @@ const requiredVersion = "13"
 
 // Protocol-level errors.
 var (
-	ErrCloseStatusInvalid     = errors.New("close frame status code out of range")
-	ErrCloseStatusReserved    = errors.New("close frame status code is reserve")
+	ErrCloseStatusInvalid     = errors.New("close status code out of range")
+	ErrCloseStatusReserved    = errors.New("close status code is reserved")
 	ErrContinuationExpected   = errors.New("expected continuation frame")
 	ErrControlFrameFragmented = errors.New("control frame must not be fragmented")
 	ErrControlFrameTooLarge   = errors.New("control frame payload exceeds 125 bytes")

--- a/proto.go
+++ b/proto.go
@@ -332,7 +332,7 @@ var reservedStatusCodes = map[uint16]bool{
 	2999: true,
 }
 
-func validateFrame(frame *Frame, maxFrameSize int, mode Mode) error {
+func validateFrame(frame *Frame, mode Mode) error {
 	// We do not support any extensions, per the spec all RSV bits must be 0:
 	// https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
 	if frame.RSV1 || frame.RSV2 || frame.RSV3 {
@@ -348,10 +348,6 @@ func validateFrame(frame *Frame, maxFrameSize int, mode Mode) error {
 	payloadLen := len(frame.Payload)
 
 	switch frame.Opcode {
-	case OpcodeContinuation, OpcodeText, OpcodeBinary:
-		if payloadLen > maxFrameSize {
-			return ErrFrameTooLarge
-		}
 	case OpcodeClose, OpcodePing, OpcodePong:
 		// All control frames MUST have a payload length of 125 bytes or less
 		// and MUST NOT be fragmented.

--- a/proto_test.go
+++ b/proto_test.go
@@ -20,7 +20,7 @@ func TestFrameRoundTrip(t *testing.T) {
 		Payload: []byte("hello"),
 	}
 	buf := &bytes.Buffer{}
-	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, makeMaskingKey()))
+	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, websocket.NewMaskingKey()))
 
 	// read "server" frame from buffer.
 	serverFrame, err := websocket.ReadFrame(buf, len(clientFrame.Payload))
@@ -44,7 +44,7 @@ func TestMaxFrameSize(t *testing.T) {
 		Payload: []byte("hello"),
 	}
 	buf := &bytes.Buffer{}
-	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, makeMaskingKey()))
+	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, websocket.NewMaskingKey()))
 
 	// read "server" frame from buffer.
 	serverFrame, err := websocket.ReadFrame(buf, len(clientFrame.Payload)-1)

--- a/websocket.go
+++ b/websocket.go
@@ -175,7 +175,7 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 			}
 			return nil, ws.closeOnReadError(code, err)
 		}
-		if err := validateFrame(frame, ws.maxFrameSize, ws.mode); err != nil {
+		if err := validateFrame(frame, ws.mode); err != nil {
 			return nil, ws.closeOnReadError(StatusProtocolError, err)
 		}
 		ws.hooks.OnReadFrame(ws.clientKey, frame)

--- a/websocket.go
+++ b/websocket.go
@@ -207,7 +207,7 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 		if frame.Fin {
 			ws.hooks.OnReadMessage(ws.clientKey, msg)
 			if !msg.Binary && !utf8.Valid(msg.Payload) {
-				return nil, ws.closeOnReadError(StatusUnsupportedPayload, ErrInvalidUT8)
+				return nil, ws.closeOnReadError(StatusUnsupportedPayload, ErrInvalidUTF8)
 			}
 			return msg, nil
 		}

--- a/websocket.go
+++ b/websocket.go
@@ -278,7 +278,11 @@ func (ws *Websocket) Close() error {
 func (ws *Websocket) closeWithError(code StatusCode, err error) error {
 	ws.hooks.OnClose(ws.clientKey, code, err)
 	close(ws.closedCh)
-	if err := WriteFrame(ws.conn, CloseFrame(code, err)); err != nil {
+	var reason string
+	if err != nil {
+		reason = err.Error()
+	}
+	if err := WriteFrame(ws.conn, CloseFrame(code, reason)); err != nil {
 		return fmt.Errorf("websocket: failed to write close frame: %w", err)
 	}
 	if err := ws.conn.Close(); err != nil {

--- a/websocket.go
+++ b/websocket.go
@@ -29,6 +29,15 @@ const (
 	DefaultMaxMessageSize int = 1024 * 256 // 256KiB
 )
 
+// Mode enalbes server or client behavior
+type Mode bool
+
+// Valid modes
+const (
+	ServerMode Mode = false
+	ClientMode      = true
+)
+
 // Options define the limits imposed on a websocket connection.
 type Options struct {
 	Hooks          Hooks
@@ -48,7 +57,7 @@ type Websocket struct {
 	// connection state
 	conn     io.ReadWriteCloser
 	closedCh chan struct{}
-	server   bool
+	mode     Mode
 
 	// observability
 	clientKey ClientKey
@@ -79,14 +88,14 @@ func Accept(w http.ResponseWriter, r *http.Request, opts Options) (*Websocket, e
 		panic(fmt.Errorf("websocket: accept: hijack failed: %s", err))
 	}
 
-	return New(conn, clientKey, opts), nil
+	return New(conn, clientKey, ServerMode, opts), nil
 }
 
 // New manually creates a new websocket connection. Caller is responsible for
 // completing initial handshake before creating a websocket connection.
 //
 // Prefer Accept() when possible.
-func New(src io.ReadWriteCloser, clientKey ClientKey, opts Options) *Websocket {
+func New(src io.ReadWriteCloser, clientKey ClientKey, mode Mode, opts Options) *Websocket {
 	setDefaults(&opts)
 	if opts.ReadTimeout != 0 || opts.WriteTimeout != 0 {
 		if _, ok := src.(deadliner); !ok {
@@ -96,7 +105,7 @@ func New(src io.ReadWriteCloser, clientKey ClientKey, opts Options) *Websocket {
 	return &Websocket{
 		conn:           src,
 		closedCh:       make(chan struct{}),
-		server:         true,
+		mode:           mode,
 		clientKey:      clientKey,
 		hooks:          opts.Hooks,
 		readTimeout:    opts.ReadTimeout,
@@ -166,7 +175,7 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 			}
 			return nil, ws.closeOnReadError(code, err)
 		}
-		if err := validateFrame(frame, ws.maxFrameSize, ws.server); err != nil {
+		if err := validateFrame(frame, ws.maxFrameSize, ws.mode); err != nil {
 			return nil, ws.closeOnReadError(StatusProtocolError, err)
 		}
 		ws.hooks.OnReadFrame(ws.clientKey, frame)

--- a/websocket.go
+++ b/websocket.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -300,6 +301,7 @@ func (ws *Websocket) closeOnWriteError(code StatusCode, err error) error {
 }
 
 func (ws *Websocket) resetReadDeadline() {
+	log.Printf("XXX setting read timeout to %v", ws.readTimeout)
 	if ws.readTimeout <= 0 {
 		return
 	}

--- a/websocket.go
+++ b/websocket.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -301,7 +300,6 @@ func (ws *Websocket) closeOnWriteError(code StatusCode, err error) error {
 }
 
 func (ws *Websocket) resetReadDeadline() {
-	log.Printf("XXX setting read timeout to %v", ws.readTimeout)
 	if ws.readTimeout <= 0 {
 		return
 	}

--- a/websocket.go
+++ b/websocket.go
@@ -185,7 +185,7 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 				return nil, ws.closeOnReadError(StatusProtocolError, ErrInvalidContinuation)
 			}
 			if len(msg.Payload)+len(frame.Payload) > ws.maxMessageSize {
-				return nil, ws.closeOnReadError(StatusTooLarge, fmt.Errorf("message size exceeds maximum of %d bytes", ws.maxMessageSize))
+				return nil, ws.closeOnReadError(StatusTooLarge, ErrMessageTooLarge)
 			}
 			msg.Payload = append(msg.Payload, frame.Payload...)
 		case OpcodeClose:
@@ -205,10 +205,10 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 		}
 
 		if frame.Fin {
-			ws.hooks.OnReadMessage(ws.clientKey, msg)
 			if !msg.Binary && !utf8.Valid(msg.Payload) {
 				return nil, ws.closeOnReadError(StatusUnsupportedPayload, ErrInvalidUTF8)
 			}
+			ws.hooks.OnReadMessage(ws.clientKey, msg)
 			return msg, nil
 		}
 	}

--- a/websocket_autobahn_test.go
+++ b/websocket_autobahn_test.go
@@ -33,7 +33,7 @@ var defaultExcludedTestCases = []string{
 	"13.*",
 }
 
-func TestWebSocketServer(t *testing.T) {
+func TestAutobahn(t *testing.T) {
 	t.Parallel()
 
 	// TODO: document AUTOBAHN_* env vars that control test functionality
@@ -133,7 +133,7 @@ func TestWebSocketServer(t *testing.T) {
 	}
 
 	t.Logf("autobahn test report: file://%s", path.Join(testDir, "report/index.html"))
-	if os.Getenv("AUTOBAHN_OPEN_REPORT") != "" {
+	if os.Getenv("AUTOBAHN_REPORT") == "1" {
 		runCmd(t, exec.Command("open", path.Join(testDir, "report/index.html")))
 	}
 }

--- a/websocket_benchmark_test.go
+++ b/websocket_benchmark_test.go
@@ -93,7 +93,7 @@ func BenchmarkReadMessage(b *testing.B) {
 			fin := i == frameCount-1
 			b.Logf("frame=%d frameCount=%d fin=%v", i, frameCount, fin)
 			frame := makeFrame(opcode, fin, frameSize)
-			assert.NilError(b, websocket.WriteFrameMasked(buf, frame, makeMaskingKey()))
+			assert.NilError(b, websocket.WriteFrameMasked(buf, frame, websocket.NewMaskingKey()))
 		}
 
 		payload := buf.Bytes()
@@ -102,7 +102,7 @@ func BenchmarkReadMessage(b *testing.B) {
 			in:  reader,
 			out: io.Discard,
 		}
-		ws := websocket.New(conn, websocket.ClientKey(makeClientKey()), websocket.Options{
+		ws := websocket.New(conn, websocket.NewClientKey(), websocket.Options{
 			MaxFrameSize:   frameSize,
 			MaxMessageSize: msgSize,
 			// Hooks:           newTestHooks(b),

--- a/websocket_benchmark_test.go
+++ b/websocket_benchmark_test.go
@@ -102,7 +102,7 @@ func BenchmarkReadMessage(b *testing.B) {
 			in:  reader,
 			out: io.Discard,
 		}
-		ws := websocket.New(conn, websocket.NewClientKey(), websocket.Options{
+		ws := websocket.New(conn, websocket.NewClientKey(), websocket.ServerMode, websocket.Options{
 			MaxFrameSize:   frameSize,
 			MaxMessageSize: msgSize,
 			// Hooks:           newTestHooks(b),

--- a/websocket_internal_test.go
+++ b/websocket_internal_test.go
@@ -14,7 +14,7 @@ func TestDefaults(t *testing.T) {
 		conn net.Conn
 		key  = ClientKey("test-client-key")
 		opts = Options{}
-		ws   = New(conn, key, opts)
+		ws   = New(conn, key, ServerMode, opts)
 	)
 
 	assert.Equal(t, ws.ClientKey(), key, "incorrect client key")
@@ -22,7 +22,7 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, ws.maxMessageSize, DefaultMaxMessageSize, "incorrect max message size")
 	assert.Equal(t, ws.readTimeout, 0, "incorrect read timeout")
 	assert.Equal(t, ws.writeTimeout, 0, "incorrect write timeout")
-	assert.Equal(t, ws.server, true, "incorrect server value")
+	assert.Equal(t, ws.mode, ServerMode, "incorrect mode value")
 	assert.Equal(t, ws.hooks.OnClose != nil, true, "OnClose hook is nil")
 	assert.Equal(t, ws.hooks.OnReadError != nil, true, "OnReadError hook is nil")
 	assert.Equal(t, ws.hooks.OnReadFrame != nil, true, "OnReadFrame hook is nil")

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -671,7 +671,6 @@ func TestProtocolErrors(t *testing.T) {
 		},
 		"unknown opcode": {
 			frames: []*websocket.Frame{
-
 				{
 					Opcode: websocket.Opcode(255),
 					Fin:    true,

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -880,8 +880,8 @@ func setupRawConnWithHandler(t testing.TB, handler http.Handler) net.Conn {
 	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
 	assert.NilError(t, err)
 	t.Cleanup(func() {
-		srv.Close()
 		conn.Close()
+		srv.Close()
 	})
 
 	handshakeReq := httptest.NewRequest(http.MethodGet, "/", nil)


### PR DESCRIPTION
A major update to unit tests.  Because these tests now provide more coverage than autobahn, we can move the autobahn CI tests to a parallel job and get code coverage results faster.

In addition, this adds a few API changes driven by writing more tests:
- `NewClientKey()` and `NewMaskingKey()` promoted from internal helpers
- Explicit `ServerMode` and `ClientMode` to determine frame masking behavior
- A number of new errors