### PR TITLE
refactor: unify WriteFrame/WriteFrameMasked

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To run the autobahn fuzzing client in its default configuration, use:
 make testautobahn
 ```
 
-There are a variety of options that can be enabled individually or altogether,
+There are a variety of options that can be enabled individually or together,
 which are useful for viewing the generated HTML test report, narrowing the
 set of test cases to debug a particular issue, or to enable more detailed
 debug logging.

--- a/example_test.go
+++ b/example_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/mccutchen/websocket"
 )
 
-func ExampleEchoHandler() {
+func ExampleServe() {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ws, err := websocket.Accept(w, r, websocket.Options{
 			ReadTimeout:    500 * time.Millisecond,
 			WriteTimeout:   500 * time.Millisecond,
-			MaxFrameSize:   16 * 1024,   // 16KiB
-			MaxMessageSize: 1024 * 1024, // 1MiB
+			MaxFrameSize:   16 << 10, // 16KiB
+			MaxMessageSize: 1 << 20,  // 1MiB
 		})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/examples/echoserver/main.go
+++ b/examples/echoserver/main.go
@@ -45,8 +45,8 @@ func main() {
 			// the autobahn websocket test suite.
 			//
 			// Prefer much lower limits when your application allows it.
-			MaxFrameSize:   1024 * 1024 * 16,
-			MaxMessageSize: 1024 * 1024 * 16,
+			MaxFrameSize:   16 << 20, // 16 MiB
+			MaxMessageSize: 16 << 20,
 		})
 		if err != nil {
 			logger.ErrorContext(r.Context(), "websocket handshake failed", "error", err.Error())

--- a/proto_test.go
+++ b/proto_test.go
@@ -20,7 +20,7 @@ func TestFrameRoundTrip(t *testing.T) {
 		Payload: []byte("hello"),
 	}
 	buf := &bytes.Buffer{}
-	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, websocket.NewMaskingKey()))
+	assert.NilError(t, websocket.WriteFrame(buf, websocket.NewMaskingKey(), clientFrame))
 
 	// read "server" frame from buffer.
 	serverFrame, err := websocket.ReadFrame(buf, len(clientFrame.Payload))
@@ -44,7 +44,7 @@ func TestMaxFrameSize(t *testing.T) {
 		Payload: []byte("hello"),
 	}
 	buf := &bytes.Buffer{}
-	assert.NilError(t, websocket.WriteFrameMasked(buf, clientFrame, websocket.NewMaskingKey()))
+	assert.NilError(t, websocket.WriteFrame(buf, websocket.NewMaskingKey(), clientFrame))
 
 	// read "server" frame from buffer.
 	serverFrame, err := websocket.ReadFrame(buf, len(clientFrame.Payload)-1)

--- a/websocket.go
+++ b/websocket.go
@@ -195,7 +195,7 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 			}
 		case OpcodeContinuation:
 			if msg == nil {
-				return nil, ws.closeOnReadError(StatusProtocolError, ErrInvalidContinuation)
+				return nil, ws.closeOnReadError(StatusProtocolError, ErrContinuationUnexpected)
 			}
 			if len(msg.Payload)+len(frame.Payload) > ws.maxMessageSize {
 				return nil, ws.closeOnReadError(StatusTooLarge, ErrMessageTooLarge)
@@ -214,12 +214,12 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 		case OpcodePong:
 			continue // no-op
 		default:
-			return nil, ws.closeOnReadError(StatusProtocolError, fmt.Errorf("unsupported opcode: %v", frame.Opcode))
+			return nil, ws.closeOnReadError(StatusProtocolError, ErrOpcodeUnknown)
 		}
 
 		if frame.Fin {
 			if !msg.Binary && !utf8.Valid(msg.Payload) {
-				return nil, ws.closeOnReadError(StatusUnsupportedPayload, ErrInvalidUTF8)
+				return nil, ws.closeOnReadError(StatusUnsupportedPayload, ErrEncodingInvalid)
 			}
 			ws.hooks.OnReadMessage(ws.clientKey, msg)
 			return msg, nil

--- a/websocket_autobahn_test.go
+++ b/websocket_autobahn_test.go
@@ -65,9 +65,9 @@ func TestAutobahn(t *testing.T) {
 				ReadTimeout:  5000 * time.Millisecond,
 				WriteTimeout: 500 * time.Millisecond,
 				// some autobahn test cases send large frames, so we need to
-				// support large frames and messages
-				MaxFrameSize:   1024 * 1024 * 16,
-				MaxMessageSize: 1024 * 1024 * 16,
+				// support frames and messages up to 16 MiB
+				MaxFrameSize:   16 << 20,
+				MaxMessageSize: 16 << 20,
 			})
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)

--- a/websocket_benchmark_test.go
+++ b/websocket_benchmark_test.go
@@ -28,11 +28,10 @@ func makeFrame(opcode websocket.Opcode, fin bool, payloadLen int) *websocket.Fra
 
 func BenchmarkReadFrame(b *testing.B) {
 	frameSizes := []int{
-		1024,
-		1024 * 1024,
-		// largest cases from the autobahn test suite
-		8 * 1024 * 1024,
-		16 * 1024 * 1024,
+		1 << 10,  // 1 KiB
+		1 << 20,  // 1 MiB
+		8 << 20,  // 8 MiB
+		16 << 20, // 16 MiB
 	}
 
 	for _, size := range frameSizes {
@@ -61,19 +60,19 @@ func BenchmarkReadMessage(b *testing.B) {
 		frameCount int
 	}{
 		// 1 frame per message
-		{1024 * 1024, 1},
-		{8 * 1024 * 1024, 1},
-		{16 * 1024 * 1024, 1},
+		{1 << 10, 1},
+		{8 << 20, 1},
+		{16 << 20, 1},
 
 		// 4 frames per message
-		{1024 * 1024, 4},
-		{8 * 1024 * 1024, 4},
-		{16 * 1024 * 1024, 4},
+		{1 << 10, 4},
+		{8 << 20, 4},
+		{16 << 20, 4},
 
 		// 16 frames per message
-		{1024 * 1024, 16},
-		{8 * 1024 * 1024, 16},
-		{16 * 1024 * 1024, 16},
+		{1 << 10, 16},
+		{8 << 20, 16},
+		{16 << 20, 16},
 	}
 
 	for _, tc := range testCases {

--- a/websocket_benchmark_test.go
+++ b/websocket_benchmark_test.go
@@ -37,10 +37,8 @@ func BenchmarkReadFrame(b *testing.B) {
 
 	for _, size := range frameSizes {
 		frame := makeFrame(websocket.OpcodeText, true, size)
-		mask := [4]byte{1, 2, 3, 4}
-
 		buf := &bytes.Buffer{}
-		assert.NilError(b, websocket.WriteFrameMasked(buf, frame, mask))
+		assert.NilError(b, websocket.WriteFrame(buf, websocket.NewMaskingKey(), frame))
 
 		// Run sub-benchmarks for each payload size
 		b.Run(formatSize(size), func(b *testing.B) {
@@ -93,7 +91,7 @@ func BenchmarkReadMessage(b *testing.B) {
 			fin := i == frameCount-1
 			b.Logf("frame=%d frameCount=%d fin=%v", i, frameCount, fin)
 			frame := makeFrame(opcode, fin, frameSize)
-			assert.NilError(b, websocket.WriteFrameMasked(buf, frame, websocket.NewMaskingKey()))
+			assert.NilError(b, websocket.WriteFrame(buf, websocket.NewMaskingKey(), frame))
 		}
 
 		payload := buf.Bytes()

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -562,7 +562,7 @@ func TestProtocolErrors(t *testing.T) {
 				},
 			},
 			wantCloseCode:   websocket.StatusProtocolError,
-			wantCloseReason: websocket.ErrInvalidContinuation,
+			wantCloseReason: websocket.ErrContinuationUnexpected,
 		},
 		"max frame size": {
 			frames: []*websocket.Frame{
@@ -608,7 +608,7 @@ func TestProtocolErrors(t *testing.T) {
 			},
 			unmasked:        true,
 			wantCloseCode:   websocket.StatusProtocolError,
-			wantCloseReason: websocket.ErrUnmaskedClientFrame,
+			wantCloseReason: websocket.ErrClientFrameUnmasked,
 		},
 		"server rejects RSV bits": {
 			frames: []*websocket.Frame{
@@ -620,7 +620,7 @@ func TestProtocolErrors(t *testing.T) {
 				},
 			},
 			wantCloseCode:   websocket.StatusProtocolError,
-			wantCloseReason: websocket.ErrUnsupportedRSVBits,
+			wantCloseReason: websocket.ErrRSVBitsUnsupported,
 		},
 		"control frames must not be fragmented": {
 			frames: []*websocket.Frame{
@@ -652,7 +652,7 @@ func TestProtocolErrors(t *testing.T) {
 				},
 			},
 			wantCloseCode:   websocket.StatusUnsupportedPayload,
-			wantCloseReason: websocket.ErrInvalidUTF8,
+			wantCloseReason: websocket.ErrEncodingInvalid,
 		},
 		"missing continuation frame": {
 			frames: []*websocket.Frame{
@@ -678,7 +678,7 @@ func TestProtocolErrors(t *testing.T) {
 				},
 			},
 			wantCloseCode:   websocket.StatusProtocolError,
-			wantCloseReason: websocket.ErrUnknownOpcode,
+			wantCloseReason: websocket.ErrOpcodeUnknown,
 		},
 	}
 	for name, tc := range testCases {
@@ -735,27 +735,27 @@ func TestCloseFrames(t *testing.T) {
 				Payload: []byte("X"),
 			},
 			wantCode:   websocket.StatusProtocolError,
-			wantReason: "close frame payload must be at least 2 bytes",
+			wantReason: websocket.ErrClosePayloadInvalid.Error(),
 		},
 		"invalid close code (too low)": {
 			frame:      websocket.NewCloseFrame(websocket.StatusCode(999), ""),
 			wantCode:   websocket.StatusProtocolError,
-			wantReason: "close status code out of range",
+			wantReason: websocket.ErrCloseStatusInvalid.Error(),
 		},
 		"invalid close code (too high))": {
 			frame:      websocket.NewCloseFrame(websocket.StatusCode(5001), ""),
 			wantCode:   websocket.StatusProtocolError,
-			wantReason: "close status code out of range",
+			wantReason: websocket.ErrCloseStatusInvalid.Error(),
 		},
 		"reserved close code": {
 			frame:      websocket.NewCloseFrame(websocket.StatusCode(1015), ""),
 			wantCode:   websocket.StatusProtocolError,
-			wantReason: "close status code is reserved",
+			wantReason: websocket.ErrCloseStatusReserved.Error(),
 		},
 		"invalid utf8 in close reason": {
 			frame:      frameWithInvalidUTF8Reason(),
 			wantCode:   websocket.StatusProtocolError,
-			wantReason: "invalid UTF-8",
+			wantReason: websocket.ErrEncodingInvalid.Error(),
 		},
 	}
 

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -454,7 +454,11 @@ func TestProtocolOkay(t *testing.T) {
 
 	t.Run("jumbo frames okay", func(t *testing.T) {
 		t.Parallel()
-		jumboSize := 64 * 1024 // payloads of length 65536 or more must be encoded as 8 bytes
+
+		// Ensure we're exercising extended payload length parsing, where
+		// payloads of length 65536 (64 KiB) or more must be encoded as 8
+		// bytes
+		jumboSize := 64 << 10 // == 64 KiB == 65536
 		conn := setupRawConn(t, websocket.Options{
 			MaxFrameSize:   jumboSize,
 			MaxMessageSize: jumboSize,


### PR DESCRIPTION
Also
- split MarshalFrame out of WriteFrame for easier reuse (especially in tests)
- rename CloseFrame -> NewCloseFrame for clarity
- rename public errors and their messages for more consistency