### PR TITLE
refactor: complete rewrite of the frame type

### DIFF
--- a/proto.go
+++ b/proto.go
@@ -36,12 +36,12 @@ type Opcode uint8
 // See the RFC for the set of defined opcodes:
 // https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
 const (
-	OpcodeContinuation Opcode = 0x0
-	OpcodeText         Opcode = 0x1
-	OpcodeBinary       Opcode = 0x2
-	OpcodeClose        Opcode = 0x8
-	OpcodePing         Opcode = 0x9
-	OpcodePong         Opcode = 0xA
+	OpcodeContinuation Opcode = 0b0000_0000
+	OpcodeText         Opcode = 0b0000_0001
+	OpcodeBinary       Opcode = 0b0000_0010
+	OpcodeClose        Opcode = 0b0000_1000
+	OpcodePing         Opcode = 0b0000_1001
+	OpcodePong         Opcode = 0b0000_1010
 )
 
 func (c Opcode) String() string {
@@ -82,33 +82,91 @@ const (
 	StatusServerError        StatusCode = 1011
 )
 
-// RSV bit masks
 const (
-	rsv1mask = 0b100
-	rsv2mask = 0b010
-	rsv3mask = 0b001
+	// first header byte
+	finMask    = 0b1000_0000
+	opcodeMask = 0b0000_1111
+
+	// second header byte
+	maskedMask     = 0b1000_0000
+	payloadLenMask = 0b0111_1111
 )
+
+// RSVBit is a bit mask for RSV bits 1-3
+type RSVBit byte
+
+// RSV bits 1-3
+const (
+	RSV1 RSVBit = 0b0100_0000
+	RSV2 RSVBit = 0b0010_0000
+	RSV3 RSVBit = 0b0001_0000
+)
+
+// NewFrame creates a new websocket frame with the given opcode, fin bit, and
+// payload.
+func NewFrame(opcode Opcode, fin bool, payload []byte, rsv ...RSVBit) *Frame {
+	f := &Frame{
+		payload: payload,
+	}
+	// Encode FIN, RSV1-3, and OPCODE.
+	//
+	// The second header byte encodes mask bit and payload size, but in-memory
+	// frames are unmasked and the payload size is directly accessible.
+	//
+	// These bits will be encoded as necessary when writing a frame.
+	if fin {
+		f.header |= finMask
+	}
+	for _, r := range rsv {
+		f.header |= byte(r)
+	}
+	f.header |= uint8(opcode) & opcodeMask
+	return f
+}
+
+// NewCloseFrame creates a close frame with an optional error message.
+func NewCloseFrame(code StatusCode, reason string) *Frame {
+	var payload []byte
+	if code > 0 {
+		payload = make([]byte, 0, 2+len(reason))
+		payload = binary.BigEndian.AppendUint16(payload, uint16(code))
+		payload = append(payload, []byte(reason)...)
+	}
+	return NewFrame(OpcodeClose, true, payload)
+}
 
 // Frame is a websocket protocol frame.
 type Frame struct {
-	Fin     bool
-	RSV     byte // Bits 0-2 represent RSV1-3
-	Opcode  Opcode
-	Payload []byte
-	Masked  bool
+	header  byte
+	payload []byte
+}
+
+// Fin returns a bool indicating whether the frame's FIN bit is set.
+func (f *Frame) Fin() bool {
+	return f.header&finMask != 0
+}
+
+// Opcode returns the the frame's OPCODE.
+func (f *Frame) Opcode() Opcode {
+	return Opcode(f.header & opcodeMask)
 }
 
 // RSV1 returns true if the frame's RSV1 bit is set
-func (f *Frame) RSV1() bool { return f.RSV&rsv1mask != 0 }
+func (f *Frame) RSV1() bool { return f.header&byte(RSV1) != 0 }
 
 // RSV2 returns true if the frame's RSV2 bit is set
-func (f *Frame) RSV2() bool { return f.RSV&rsv2mask != 0 }
+func (f *Frame) RSV2() bool { return f.header&byte(RSV2) != 0 }
 
 // RSV3 returns true if the frame's RSV3 bit is set
-func (f *Frame) RSV3() bool { return f.RSV&rsv3mask != 0 }
+func (f *Frame) RSV3() bool { return f.header&byte(RSV3) != 0 }
+
+// Payload returns the frame's payload.
+func (f *Frame) Payload() []byte {
+	return f.payload
+}
 
 func (f Frame) String() string {
-	return fmt.Sprintf("Frame{Fin: %v, Opcode: %v, Payload: %s}", f.Fin, f.Opcode, formatPayload(f.Payload))
+	return fmt.Sprintf("Frame{Fin: %v, Opcode: %v, Payload: %s}", f.Fin(), f.Opcode(), formatPayload(f.Payload()))
 }
 
 // Message is an application-level message from the client, which may be
@@ -132,26 +190,27 @@ var formatPayload = func(p []byte) string {
 }
 
 // ReadFrame reads a websocket frame from the wire.
-func ReadFrame(buf io.Reader, maxPayloadLen int) (*Frame, error) {
-	bb := make([]byte, 2)
-	if _, err := io.ReadFull(buf, bb); err != nil {
+func ReadFrame(buf io.Reader, mode Mode, maxPayloadLen int) (*Frame, error) {
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(buf, header); err != nil {
 		return nil, fmt.Errorf("error reading frame header: %w", err)
 	}
 
-	// parse first header byte
+	frame := &Frame{
+		header: header[0],
+	}
+
+	// figure out how to parse payload
 	var (
-		b0     = bb[0]
-		fin    = b0&0b1000_0000 != 0
-		rsv    = (b0 >> 4) & 0b0111
-		opcode = Opcode(b0 & 0b0000_1111)
+		masked     = header[1]&maskedMask != 0
+		payloadLen = uint64(header[1] & payloadLenMask)
 	)
 
-	// parse second header byte
-	var (
-		b1         = bb[1]
-		masked     = b1&0b1000_0000 != 0
-		payloadLen = uint64(b1 & 0b0111_1111)
-	)
+	// If the data is being sent by the client, the frame(s) MUST be masked
+	// https://datatracker.ietf.org/doc/html/rfc6455#section-6.1
+	if mode == ServerMode && !masked {
+		return nil, ErrClientFrameUnmasked
+	}
 
 	// Payload lengths 0 to 125 encoded directly in last 7 bits of payload
 	// field, but we may need to read an "extended" payload length.
@@ -186,23 +245,16 @@ func ReadFrame(buf io.Reader, maxPayloadLen int) (*Frame, error) {
 	}
 
 	// read & optionally unmask payload
-	payload := make([]byte, payloadLen)
-	if _, err := io.ReadFull(buf, payload); err != nil {
+	frame.payload = make([]byte, payloadLen)
+	if _, err := io.ReadFull(buf, frame.Payload()); err != nil {
 		return nil, fmt.Errorf("error reading %d byte payload: %w", payloadLen, err)
 	}
 	if masked {
-		for i, b := range payload {
-			payload[i] = b ^ mask[i%4]
+		for i, b := range frame.Payload() {
+			frame.Payload()[i] = b ^ mask[i%4]
 		}
 	}
-
-	return &Frame{
-		Fin:     fin,
-		RSV:     rsv,
-		Opcode:  opcode,
-		Payload: payload,
-		Masked:  masked,
-	}, nil
+	return frame, nil
 }
 
 // WriteFrame writes a masked websocket frame to the wire.
@@ -218,17 +270,10 @@ func WriteFrame(dst io.Writer, mask MaskingKey, frame *Frame) error {
 func MarshalFrame(frame *Frame, mask MaskingKey) []byte {
 	// worst case payload size is 13 header bytes + payload size, where 13 is
 	// (1 byte header) + (1-8 byte length) + (0-4 byte mask key)
-	buf := make([]byte, 0, 13+len(frame.Payload))
+	buf := make([]byte, 0, marshaledSize(frame, mask))
 	masked := mask != Unmasked
 
-	// FIN, RSV1-3, OPCODE
-	var b0 byte
-	if frame.Fin {
-		b0 |= 0b1000_0000
-	}
-	b0 |= (frame.RSV & 0b111) << 4
-	b0 |= uint8(frame.Opcode) & 0b0000_1111
-	buf = append(buf, b0)
+	buf = append(buf, frame.header)
 
 	// Masked bit, payload length
 	var b1 byte
@@ -236,7 +281,7 @@ func MarshalFrame(frame *Frame, mask MaskingKey) []byte {
 		b1 |= 0b1000_0000
 	}
 
-	payloadLen := int64(len(frame.Payload))
+	payloadLen := int64(len(frame.Payload()))
 	switch {
 	case payloadLen <= 125:
 		buf = append(buf, b1|byte(payloadLen))
@@ -251,33 +296,34 @@ func MarshalFrame(frame *Frame, mask MaskingKey) []byte {
 	// Optional masking key and actual payload
 	if masked {
 		buf = append(buf, mask[:]...)
-		for i, b := range frame.Payload {
+		for i, b := range frame.Payload() {
 			buf = append(buf, b^mask[i%4])
 		}
 	} else {
-		buf = append(buf, frame.Payload...)
+		buf = append(buf, frame.Payload()...)
 	}
 	return buf
 }
 
-// NewCloseFrame creates a close frame with an optional error message.
-func NewCloseFrame(code StatusCode, reason string) *Frame {
-	var payload []byte
-	if code > 0 {
-		payload = make([]byte, 0, 2+len(reason))
-		payload = binary.BigEndian.AppendUint16(payload, uint16(code))
-		payload = append(payload, []byte(reason)...)
+// marshaledSize returns the number of bytes required to marshal a frame.
+func marshaledSize(f *Frame, mask MaskingKey) int {
+	payloadLen := len(f.Payload())
+	size := 2 + payloadLen
+	switch {
+	case payloadLen >= 64<<10:
+		size += 8
+	case payloadLen > 125:
+		size += 2
 	}
-	return &Frame{
-		Fin:     true,
-		Opcode:  OpcodeClose,
-		Payload: payload,
+	if mask != Unmasked {
+		size += 4
 	}
+	return size
 }
 
-// messageFrames splits a message into N frames with payloads of at most
+// FrameMessage splits a message into N frames with payloads of at most
 // frameSize bytes.
-func messageFrames(msg *Message, frameSize int) []*Frame {
+func FrameMessage(msg *Message, frameSize int) []*Frame {
 	var result []*Frame
 
 	fin := false
@@ -297,11 +343,7 @@ func messageFrames(msg *Message, frameSize int) []*Frame {
 			fin = true
 			end = dataLen
 		}
-		result = append(result, &Frame{
-			Fin:     fin,
-			Opcode:  opcode,
-			Payload: msg.Payload[offset:end],
-		})
+		result = append(result, NewFrame(opcode, fin, msg.Payload[offset:end]))
 		if fin {
 			break
 		}
@@ -327,22 +369,15 @@ var reservedStatusCodes = map[uint16]bool{
 	2999: true,
 }
 
-func validateFrame(frame *Frame, mode Mode) error {
+func validateFrame(frame *Frame) error {
 	// We do not support any extensions, per the spec all RSV bits must be 0:
 	// https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
-	if frame.RSV != 0 {
+	if frame.header&uint8(RSV1|RSV2|RSV3) != 0 {
 		return ErrRSVBitsUnsupported
 	}
 
-	// If the data is being sent by the client, the frame(s) MUST be masked
-	// https://datatracker.ietf.org/doc/html/rfc6455#section-6.1
-	if mode == ServerMode && !frame.Masked {
-		return ErrClientFrameUnmasked
-	}
-
-	payloadLen := len(frame.Payload)
-
-	switch frame.Opcode {
+	payloadLen := len(frame.Payload())
+	switch frame.Opcode() {
 	case OpcodeClose, OpcodePing, OpcodePong:
 		// All control frames MUST have a payload length of 125 bytes or less
 		// and MUST NOT be fragmented.
@@ -350,12 +385,12 @@ func validateFrame(frame *Frame, mode Mode) error {
 		if payloadLen > 125 {
 			return ErrControlFrameTooLarge
 		}
-		if !frame.Fin {
+		if !frame.Fin() {
 			return ErrControlFrameFragmented
 		}
 	}
 
-	if frame.Opcode == OpcodeClose {
+	if frame.Opcode() == OpcodeClose {
 		if payloadLen == 0 {
 			return nil
 		}
@@ -363,14 +398,14 @@ func validateFrame(frame *Frame, mode Mode) error {
 			return ErrClosePayloadInvalid
 		}
 
-		code := binary.BigEndian.Uint16(frame.Payload[:2])
+		code := binary.BigEndian.Uint16(frame.Payload()[:2])
 		if code < 1000 || code >= 5000 {
 			return ErrCloseStatusInvalid
 		}
 		if reservedStatusCodes[code] {
 			return ErrCloseStatusReserved
 		}
-		if payloadLen > 2 && !utf8.Valid(frame.Payload[2:]) {
+		if payloadLen > 2 && !utf8.Valid(frame.Payload()[2:]) {
 			return ErrEncodingInvalid
 		}
 	}

--- a/proto.go
+++ b/proto.go
@@ -36,12 +36,12 @@ type Opcode uint8
 // See the RFC for the set of defined opcodes:
 // https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
 const (
-	OpcodeContinuation Opcode = 0b0000_0000
-	OpcodeText         Opcode = 0b0000_0001
-	OpcodeBinary       Opcode = 0b0000_0010
-	OpcodeClose        Opcode = 0b0000_1000
-	OpcodePing         Opcode = 0b0000_1001
-	OpcodePong         Opcode = 0b0000_1010
+	OpcodeContinuation Opcode = 0b0000_0000 // 0x0
+	OpcodeText         Opcode = 0b0000_0001 // 0x1
+	OpcodeBinary       Opcode = 0b0000_0010 // 0x2
+	OpcodeClose        Opcode = 0b0000_1000 // 0x8
+	OpcodePing         Opcode = 0b0000_1001 // 0x9
+	OpcodePong         Opcode = 0b0000_1010 // 0xA
 )
 
 func (c Opcode) String() string {

--- a/proto.go
+++ b/proto.go
@@ -394,8 +394,9 @@ func validateFrame(frame *Frame) error {
 		if payloadLen == 0 {
 			return nil
 		}
-		// if a close frame has a payload, the first two bytes must encode a
+		// if a close frame has a payload, the first two bytes MUST encode a
 		// closing status code.
+		// https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1
 		if payloadLen == 1 {
 			return ErrClosePayloadInvalid
 		}

--- a/proto_test.go
+++ b/proto_test.go
@@ -20,7 +20,7 @@ func TestFrameRoundTrip(t *testing.T) {
 	assert.NilError(t, websocket.WriteFrame(buf, websocket.NewMaskingKey(), clientFrame))
 
 	// read "server" frame from buffer.
-	serverFrame, err := websocket.ReadFrame(buf, websocket.ServerMode, len(clientFrame.Payload()))
+	serverFrame, err := websocket.ReadFrame(buf, websocket.ServerMode, len(clientFrame.Payload))
 	assert.NilError(t, err)
 
 	// ensure client and server frame match
@@ -38,7 +38,7 @@ func TestMaxFrameSize(t *testing.T) {
 	assert.NilError(t, websocket.WriteFrame(buf, websocket.NewMaskingKey(), clientFrame))
 
 	// read "server" frame from buffer.
-	serverFrame, err := websocket.ReadFrame(buf, websocket.ServerMode, len(clientFrame.Payload())-1)
+	serverFrame, err := websocket.ReadFrame(buf, websocket.ServerMode, len(clientFrame.Payload)-1)
 	assert.Error(t, err, websocket.ErrFrameTooLarge)
 	assert.Equal(t, serverFrame, nil, "expected nil frame on error")
 }

--- a/websocket.go
+++ b/websocket.go
@@ -168,7 +168,7 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 			ws.resetReadDeadline()
 		}
 
-		frame, err := ReadFrame(ws.conn, ws.maxFrameSize)
+		frame, err := ReadFrame(ws.conn, ws.mode, ws.maxFrameSize)
 		if err != nil {
 			code := StatusServerError
 			switch {
@@ -176,36 +176,38 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 				code = StatusNormalClosure
 			case errors.Is(err, ErrFrameTooLarge):
 				code = StatusTooLarge
+			case errors.Is(err, ErrClientFrameUnmasked):
+				code = StatusProtocolError
 			}
 			return nil, ws.closeOnReadError(code, err)
 		}
-		if err := validateFrame(frame, ws.mode); err != nil {
+		if err := validateFrame(frame); err != nil {
 			return nil, ws.closeOnReadError(StatusProtocolError, err)
 		}
 		ws.hooks.OnReadFrame(ws.clientKey, frame)
 
-		switch frame.Opcode {
+		switch frame.Opcode() {
 		case OpcodeBinary, OpcodeText:
 			if msg != nil {
 				return nil, ws.closeOnReadError(StatusProtocolError, ErrContinuationExpected)
 			}
 			msg = &Message{
-				Binary:  frame.Opcode == OpcodeBinary,
-				Payload: frame.Payload,
+				Binary:  frame.Opcode() == OpcodeBinary,
+				Payload: frame.Payload(),
 			}
 		case OpcodeContinuation:
 			if msg == nil {
 				return nil, ws.closeOnReadError(StatusProtocolError, ErrContinuationUnexpected)
 			}
-			if len(msg.Payload)+len(frame.Payload) > ws.maxMessageSize {
+			if len(msg.Payload)+len(frame.Payload()) > ws.maxMessageSize {
 				return nil, ws.closeOnReadError(StatusTooLarge, ErrMessageTooLarge)
 			}
-			msg.Payload = append(msg.Payload, frame.Payload...)
+			msg.Payload = append(msg.Payload, frame.Payload()...)
 		case OpcodeClose:
 			_ = ws.Close()
 			return nil, io.EOF
 		case OpcodePing:
-			frame.Opcode = OpcodePong
+			frame = NewFrame(OpcodePong, true, frame.Payload())
 			ws.hooks.OnWriteFrame(ws.clientKey, frame)
 			if err := WriteFrame(ws.conn, ws.mask(), frame); err != nil {
 				return nil, err
@@ -217,7 +219,7 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 			return nil, ws.closeOnReadError(StatusProtocolError, ErrOpcodeUnknown)
 		}
 
-		if frame.Fin {
+		if frame.Fin() {
 			if !msg.Binary && !utf8.Valid(msg.Payload) {
 				return nil, ws.closeOnReadError(StatusUnsupportedPayload, ErrEncodingInvalid)
 			}
@@ -232,7 +234,7 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 // on any error.
 func (ws *Websocket) WriteMessage(ctx context.Context, msg *Message) error {
 	ws.hooks.OnWriteMessage(ws.clientKey, msg)
-	for _, frame := range messageFrames(msg, ws.maxFrameSize) {
+	for _, frame := range FrameMessage(msg, ws.maxFrameSize) {
 		ws.hooks.OnWriteFrame(ws.clientKey, frame)
 		select {
 		case <-ctx.Done():

--- a/websocket.go
+++ b/websocket.go
@@ -186,13 +186,14 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 		}
 		ws.hooks.OnReadFrame(ws.clientKey, frame)
 
-		switch frame.Opcode() {
+		opcode := frame.Opcode()
+		switch opcode {
 		case OpcodeBinary, OpcodeText:
 			if msg != nil {
 				return nil, ws.closeOnReadError(StatusProtocolError, ErrContinuationExpected)
 			}
 			msg = &Message{
-				Binary:  frame.Opcode() == OpcodeBinary,
+				Binary:  opcode == OpcodeBinary,
 				Payload: frame.Payload,
 			}
 		case OpcodeContinuation:

--- a/websocket.go
+++ b/websocket.go
@@ -193,21 +193,21 @@ func (ws *Websocket) ReadMessage(ctx context.Context) (*Message, error) {
 			}
 			msg = &Message{
 				Binary:  frame.Opcode() == OpcodeBinary,
-				Payload: frame.Payload(),
+				Payload: frame.Payload,
 			}
 		case OpcodeContinuation:
 			if msg == nil {
 				return nil, ws.closeOnReadError(StatusProtocolError, ErrContinuationUnexpected)
 			}
-			if len(msg.Payload)+len(frame.Payload()) > ws.maxMessageSize {
+			if len(msg.Payload)+len(frame.Payload) > ws.maxMessageSize {
 				return nil, ws.closeOnReadError(StatusTooLarge, ErrMessageTooLarge)
 			}
-			msg.Payload = append(msg.Payload, frame.Payload()...)
+			msg.Payload = append(msg.Payload, frame.Payload...)
 		case OpcodeClose:
 			_ = ws.Close()
 			return nil, io.EOF
 		case OpcodePing:
-			frame = NewFrame(OpcodePong, true, frame.Payload())
+			frame = NewFrame(OpcodePong, true, frame.Payload)
 			ws.hooks.OnWriteFrame(ws.clientKey, frame)
 			if err := WriteFrame(ws.conn, ws.mask(), frame); err != nil {
 				return nil, err

--- a/websocket_benchmark_test.go
+++ b/websocket_benchmark_test.go
@@ -18,12 +18,7 @@ func makeFrame(opcode websocket.Opcode, fin bool, payloadLen int) *websocket.Fra
 	for i := range payload {
 		payload[i] = 0x20 + byte(i%95) // Map to range 0x20 (space) to 0x7E (~)
 	}
-
-	return &websocket.Frame{
-		Opcode:  opcode,
-		Fin:     fin,
-		Payload: payload,
-	}
+	return websocket.NewFrame(opcode, fin, payload)
 }
 
 func BenchmarkReadFrame(b *testing.B) {
@@ -45,7 +40,7 @@ func BenchmarkReadFrame(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_, _ = src.Seek(0, 0)
-				_, err := websocket.ReadFrame(src, size)
+				_, err := websocket.ReadFrame(src, websocket.ServerMode, size)
 				if err != nil {
 					b.Fatalf("unexpected error: %v", err)
 				}

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -369,7 +369,7 @@ func TestProtocolOkay(t *testing.T) {
 			frame := websocket.NewFrame(websocket.OpcodeText, true, []byte("Iñtërnâtiônàlizætiøn"))
 			mustWriteFrame(t, conn, true, frame)
 			msg := mustReadMessage(t, ws)
-			assert.DeepEqual(t, msg.Payload, frame.Payload(), "incorrect message payloady")
+			assert.DeepEqual(t, msg.Payload, frame.Payload, "incorrect message payloady")
 		}
 
 		// valid UTF-8 fragmented on codepoint boundaries is okay
@@ -409,7 +409,7 @@ func TestProtocolOkay(t *testing.T) {
 		mustWriteFrame(t, conn, true, frame)
 		msg := mustReadMessage(t, ws)
 		assert.Equal(t, msg.Binary, true, "binary message")
-		assert.DeepEqual(t, msg.Payload, frame.Payload(), "binary payload")
+		assert.DeepEqual(t, msg.Payload, frame.Payload, "binary payload")
 	})
 
 	t.Run("jumbo frames okay", func(t *testing.T) {
@@ -427,7 +427,7 @@ func TestProtocolOkay(t *testing.T) {
 		clientFrame := websocket.NewFrame(websocket.OpcodeText, true, bytes.Repeat([]byte("*"), jumboSize))
 		mustWriteFrame(t, conn, true, clientFrame)
 		respFrame := mustReadFrame(t, conn, jumboSize)
-		assert.DeepEqual(t, respFrame.Payload(), clientFrame.Payload(), "payload")
+		assert.DeepEqual(t, respFrame.Payload, clientFrame.Payload, "payload")
 	})
 
 	t.Run("ping frames handled between fragments", func(t *testing.T) {
@@ -465,7 +465,7 @@ func TestProtocolOkay(t *testing.T) {
 			websocket.NewFrame(websocket.OpcodeText, true, []byte("0")),
 		})
 		respFrame := mustReadFrame(t, conn, 10)
-		assert.DeepEqual(t, respFrame.Payload(), []byte("0"), "payload")
+		assert.DeepEqual(t, respFrame.Payload, []byte("0"), "payload")
 	})
 }
 
@@ -727,7 +727,7 @@ func TestServeLoop(t *testing.T) {
 
 		// first frame should be echoed as expected
 		frame := mustReadFrame(t, conn, 128)
-		assert.DeepEqual(t, frame.Payload(), []byte("ok"), "incorrect payload")
+		assert.DeepEqual(t, frame.Payload, []byte("ok"), "incorrect payload")
 
 		// second frame should cause the websocket.Handler used by the server
 		// to return an error, which should cause the server to close the
@@ -805,9 +805,9 @@ func mustReadCloseFrame(t *testing.T, r io.Reader, wantCode websocket.StatusCode
 		return
 	}
 
-	assert.Equal(t, len(frame.Payload()) >= 2, true, "expected close frame payload to be at least 2 bytes, got %v", frame.Payload())
-	gotCode := websocket.StatusCode(binary.BigEndian.Uint16(frame.Payload()[:2]))
-	gotReason := string(frame.Payload()[2:])
+	assert.Equal(t, len(frame.Payload) >= 2, true, "expected close frame payload to be at least 2 bytes, got %v", frame.Payload)
+	gotCode := websocket.StatusCode(binary.BigEndian.Uint16(frame.Payload[:2]))
+	gotReason := string(frame.Payload[2:])
 	t.Logf("got close frame: code=%v msg=%q", gotCode, gotReason)
 	assert.Equal(t, int(gotCode), int(wantCode), "incorrect close status code")
 	if wantErr != nil {

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -309,11 +309,7 @@ func TestProtocolOkay(t *testing.T) {
 
 		// write client frame
 		conn := setupRawConn(t, newOpts(t))
-		clientFrame := &websocket.Frame{
-			Opcode:  websocket.OpcodeText,
-			Fin:     true,
-			Payload: []byte("hello"),
-		}
+		clientFrame := websocket.NewFrame(websocket.OpcodeText, true, []byte("hello"))
 		mustWriteFrame(t, conn, true, clientFrame)
 
 		// read server frame and ensure that it matches client frame
@@ -353,16 +349,8 @@ func TestProtocolOkay(t *testing.T) {
 		msgPayload = append(msgPayload, bytes.Repeat([]byte("1"), opts.MaxFrameSize)...)
 
 		mustWriteFrames(t, conn, true, []*websocket.Frame{
-			{
-				Opcode:  websocket.OpcodeText,
-				Fin:     false,
-				Payload: msgPayload[:opts.MaxFrameSize],
-			},
-			{
-				Opcode:  websocket.OpcodeContinuation,
-				Fin:     true,
-				Payload: msgPayload[opts.MaxFrameSize:],
-			},
+			websocket.NewFrame(websocket.OpcodeText, false, msgPayload[:opts.MaxFrameSize]),
+			websocket.NewFrame(websocket.OpcodeContinuation, true, msgPayload[opts.MaxFrameSize:]),
 		})
 		msg := mustReadMessage(t, ws)
 		assert.DeepEqual(t, msg.Payload, msgPayload, "incorrect messaage payload")
@@ -378,36 +366,20 @@ func TestProtocolOkay(t *testing.T) {
 
 		// valid UTF-8 accepted and echoed back
 		{
-			frame := &websocket.Frame{
-				Opcode:  websocket.OpcodeText,
-				Fin:     true,
-				Payload: []byte("Iñtërnâtiônàlizætiøn"),
-			}
+			frame := websocket.NewFrame(websocket.OpcodeText, true, []byte("Iñtërnâtiônàlizætiøn"))
 			mustWriteFrame(t, conn, true, frame)
 			msg := mustReadMessage(t, ws)
-			assert.DeepEqual(t, msg.Payload, frame.Payload, "incorrect message payloady")
+			assert.DeepEqual(t, msg.Payload, frame.Payload(), "incorrect message payloady")
 		}
 
 		// valid UTF-8 fragmented on codepoint boundaries is okay
 		{
 			mustWriteFrames(t, conn, true, []*websocket.Frame{
-				{
-					Opcode:  websocket.OpcodeText,
-					Fin:     false,
-					Payload: []byte("Iñtër"),
-				},
+				websocket.NewFrame(websocket.OpcodeText, false, []byte("Iñtër")),
 
-				{
-					Opcode:  websocket.OpcodeContinuation,
-					Fin:     false,
-					Payload: []byte("nâtiônàl"),
-				},
+				websocket.NewFrame(websocket.OpcodeContinuation, false, []byte("nâtiônàl")),
 
-				{
-					Opcode:  websocket.OpcodeContinuation,
-					Fin:     true,
-					Payload: []byte("izætiøn"),
-				},
+				websocket.NewFrame(websocket.OpcodeContinuation, true, []byte("izætiøn")),
 			})
 			msg := mustReadMessage(t, ws)
 			assert.DeepEqual(t, msg.Payload, []byte("Iñtërnâtiônàlizætiøn"), "incorrect message payloady")
@@ -417,17 +389,9 @@ func TestProtocolOkay(t *testing.T) {
 		// into a valid message
 		{
 			mustWriteFrames(t, conn, true, []*websocket.Frame{
-				{
-					Opcode:  websocket.OpcodeText,
-					Fin:     false,
-					Payload: []byte("jalape\xc3"),
-				},
+				websocket.NewFrame(websocket.OpcodeText, false, []byte("jalape\xc3")),
 
-				{
-					Opcode:  websocket.OpcodeContinuation,
-					Fin:     true,
-					Payload: []byte("\xb1o"),
-				},
+				websocket.NewFrame(websocket.OpcodeContinuation, true, []byte("\xb1o")),
 			})
 			msg := mustReadMessage(t, ws)
 			assert.DeepEqual(t, msg.Payload, []byte("jalapeño"), "payload")
@@ -441,15 +405,11 @@ func TestProtocolOkay(t *testing.T) {
 			conn = setupRawConn(t, opts)
 			ws   = setupWebsocketClient(t, conn, opts)
 		)
-		frame := &websocket.Frame{
-			Opcode:  websocket.OpcodeBinary,
-			Fin:     true,
-			Payload: []byte{0xc3},
-		}
+		frame := websocket.NewFrame(websocket.OpcodeBinary, true, []byte{0xc3})
 		mustWriteFrame(t, conn, true, frame)
 		msg := mustReadMessage(t, ws)
 		assert.Equal(t, msg.Binary, true, "binary message")
-		assert.DeepEqual(t, msg.Payload, frame.Payload, "binary payload")
+		assert.DeepEqual(t, msg.Payload, frame.Payload(), "binary payload")
 	})
 
 	t.Run("jumbo frames okay", func(t *testing.T) {
@@ -464,14 +424,10 @@ func TestProtocolOkay(t *testing.T) {
 			MaxMessageSize: jumboSize,
 			Hooks:          newTestHooks(t),
 		})
-		clientFrame := &websocket.Frame{
-			Opcode:  websocket.OpcodeText,
-			Fin:     true,
-			Payload: bytes.Repeat([]byte("*"), jumboSize),
-		}
+		clientFrame := websocket.NewFrame(websocket.OpcodeText, true, bytes.Repeat([]byte("*"), jumboSize))
 		mustWriteFrame(t, conn, true, clientFrame)
 		respFrame := mustReadFrame(t, conn, jumboSize)
-		assert.DeepEqual(t, respFrame.Payload, clientFrame.Payload, "payload")
+		assert.DeepEqual(t, respFrame.Payload(), clientFrame.Payload(), "payload")
 	})
 
 	t.Run("ping frames handled between fragments", func(t *testing.T) {
@@ -483,26 +439,15 @@ func TestProtocolOkay(t *testing.T) {
 		)
 		// write two fragmented frames with a ping control frame in between
 		mustWriteFrames(t, conn, true, []*websocket.Frame{
-			{
-				Opcode:  websocket.OpcodeText,
-				Fin:     false,
-				Payload: []byte("0"),
-			},
-			{
-				Opcode: websocket.OpcodePing,
-				Fin:    true,
-			},
-			{
-				Opcode:  websocket.OpcodeContinuation,
-				Fin:     true,
-				Payload: []byte("1"),
-			},
+			websocket.NewFrame(websocket.OpcodeText, false, []byte("0")),
+			websocket.NewFrame(websocket.OpcodePing, true, nil),
+			websocket.NewFrame(websocket.OpcodeContinuation, true, []byte("1")),
 		})
 
 		// should get a pong control frame first, even though ping was sent
 		// as second frame
 		pongFrame := mustReadFrame(t, conn, 125)
-		assert.Equal(t, pongFrame.Opcode, websocket.OpcodePong, "opcode")
+		assert.Equal(t, pongFrame.Opcode(), websocket.OpcodePong, "opcode")
 
 		// then should get the echo'd message from the two fragments
 		msg := mustReadMessage(t, ws)
@@ -516,18 +461,11 @@ func TestProtocolOkay(t *testing.T) {
 		// pong frame should be ignored, text frame should be echoed
 		conn := setupRawConn(t, newOpts(t))
 		mustWriteFrames(t, conn, true, []*websocket.Frame{
-			{
-				Opcode: websocket.OpcodePong,
-				Fin:    true,
-			},
-			{
-				Opcode:  websocket.OpcodeText,
-				Fin:     true,
-				Payload: []byte("0"),
-			},
+			websocket.NewFrame(websocket.OpcodePong, true, nil),
+			websocket.NewFrame(websocket.OpcodeText, true, []byte("0")),
 		})
 		respFrame := mustReadFrame(t, conn, 10)
-		assert.DeepEqual(t, respFrame.Payload, []byte("0"), "payload")
+		assert.DeepEqual(t, respFrame.Payload(), []byte("0"), "payload")
 	})
 }
 
@@ -559,22 +497,14 @@ func TestProtocolErrors(t *testing.T) {
 	}{
 		"unexpected continuation frame": {
 			frames: []*websocket.Frame{
-				{
-					Opcode:  websocket.OpcodeContinuation,
-					Fin:     true,
-					Payload: []byte("0"),
-				},
+				websocket.NewFrame(websocket.OpcodeContinuation, true, []byte("0")),
 			},
 			wantCloseCode:   websocket.StatusProtocolError,
 			wantCloseReason: websocket.ErrContinuationUnexpected,
 		},
 		"max frame size": {
 			frames: []*websocket.Frame{
-				{
-					Opcode:  websocket.OpcodeText,
-					Fin:     true,
-					Payload: bytes.Repeat([]byte("0"), maxFrameSize+1),
-				},
+				websocket.NewFrame(websocket.OpcodeText, true, bytes.Repeat([]byte("0"), maxFrameSize+1)),
 			},
 			wantCloseCode:   websocket.StatusTooLarge,
 			wantCloseReason: websocket.ErrFrameTooLarge,
@@ -582,33 +512,16 @@ func TestProtocolErrors(t *testing.T) {
 		"max message size": {
 			// 3rd frame will exceed max message size
 			frames: []*websocket.Frame{
-				{
-					Opcode:  websocket.OpcodeText,
-					Fin:     false,
-					Payload: bytes.Repeat([]byte("0"), maxFrameSize),
-				},
-				{
-					Opcode:  websocket.OpcodeContinuation,
-					Fin:     false,
-					Payload: bytes.Repeat([]byte("1"), maxFrameSize),
-				},
-
-				{
-					Opcode:  websocket.OpcodeContinuation,
-					Fin:     true,
-					Payload: []byte("2"),
-				},
+				websocket.NewFrame(websocket.OpcodeText, false, bytes.Repeat([]byte("0"), maxFrameSize)),
+				websocket.NewFrame(websocket.OpcodeContinuation, false, bytes.Repeat([]byte("1"), maxFrameSize)),
+				websocket.NewFrame(websocket.OpcodeContinuation, true, []byte("2")),
 			},
 			wantCloseCode:   websocket.StatusTooLarge,
 			wantCloseReason: websocket.ErrMessageTooLarge,
 		},
 		"server requires masked frames": {
 			frames: []*websocket.Frame{
-				{
-					Opcode:  websocket.OpcodeText,
-					Fin:     true,
-					Payload: []byte("hello"),
-				},
+				websocket.NewFrame(websocket.OpcodeText, true, []byte("hello")),
 			},
 			unmasked:        true,
 			wantCloseCode:   websocket.StatusProtocolError,
@@ -616,70 +529,43 @@ func TestProtocolErrors(t *testing.T) {
 		},
 		"server rejects RSV bits": {
 			frames: []*websocket.Frame{
-				{
-					Opcode:  websocket.OpcodeText,
-					RSV:     0b100,
-					Fin:     true,
-					Payload: []byte("hello"),
-				},
+				websocket.NewFrame(websocket.OpcodeText, true, []byte("hello"), websocket.RSV1),
 			},
 			wantCloseCode:   websocket.StatusProtocolError,
 			wantCloseReason: websocket.ErrRSVBitsUnsupported,
 		},
 		"control frames must not be fragmented": {
 			frames: []*websocket.Frame{
-				{
-					Opcode: websocket.OpcodeClose,
-					Fin:    false,
-				},
+				websocket.NewFrame(websocket.OpcodeClose, false, nil),
 			},
 			wantCloseCode:   websocket.StatusProtocolError,
 			wantCloseReason: websocket.ErrControlFrameFragmented,
 		},
-
 		"control frames must be less than 125 bytes": {
 			frames: []*websocket.Frame{
-				{
-					Opcode:  websocket.OpcodeClose,
-					Payload: bytes.Repeat([]byte("0"), 126),
-				},
+				websocket.NewFrame(websocket.OpcodeClose, true, bytes.Repeat([]byte("0"), 126)),
 			},
 			wantCloseCode:   websocket.StatusProtocolError,
 			wantCloseReason: websocket.ErrControlFrameTooLarge,
 		},
 		"text messages must be valid utf8": {
 			frames: []*websocket.Frame{
-				{
-					Opcode:  websocket.OpcodeText,
-					Fin:     true,
-					Payload: []byte{0xc3},
-				},
+				websocket.NewFrame(websocket.OpcodeText, true, []byte{0xc3}),
 			},
 			wantCloseCode:   websocket.StatusUnsupportedPayload,
 			wantCloseReason: websocket.ErrEncodingInvalid,
 		},
 		"missing continuation frame": {
 			frames: []*websocket.Frame{
-				{
-					Opcode:  websocket.OpcodeText,
-					Fin:     false,
-					Payload: bytes.Repeat([]byte("0"), maxFrameSize),
-				},
-				{
-					Opcode:  websocket.OpcodeText,
-					Fin:     true,
-					Payload: bytes.Repeat([]byte("1"), maxFrameSize),
-				},
+				websocket.NewFrame(websocket.OpcodeText, false, bytes.Repeat([]byte("0"), maxFrameSize)),
+				websocket.NewFrame(websocket.OpcodeText, true, bytes.Repeat([]byte("1"), maxFrameSize)),
 			},
 			wantCloseCode:   websocket.StatusProtocolError,
 			wantCloseReason: websocket.ErrContinuationExpected,
 		},
 		"unknown opcode": {
 			frames: []*websocket.Frame{
-				{
-					Opcode: websocket.Opcode(255),
-					Fin:    true,
-				},
+				websocket.NewFrame(websocket.Opcode(255), true, nil),
 			},
 			wantCloseCode:   websocket.StatusProtocolError,
 			wantCloseReason: websocket.ErrOpcodeUnknown,
@@ -712,11 +598,7 @@ func TestCloseFrames(t *testing.T) {
 		payload := make([]byte, 0, 3)
 		payload = binary.BigEndian.AppendUint16(payload, uint16(websocket.StatusNormalClosure))
 		payload = append(payload, 0xc3)
-		return &websocket.Frame{
-			Opcode:  websocket.OpcodeClose,
-			Fin:     true,
-			Payload: payload,
-		}
+		return websocket.NewFrame(websocket.OpcodeClose, true, payload)
 	}
 
 	testCases := map[string]struct {
@@ -725,19 +607,11 @@ func TestCloseFrames(t *testing.T) {
 		wantReason string
 	}{
 		"empty payload ok": {
-			frame: &websocket.Frame{
-				Opcode: websocket.OpcodeClose,
-				Fin:    true,
-			},
-			wantCode:   websocket.StatusNormalClosure,
-			wantReason: "",
+			frame:    websocket.NewFrame(websocket.OpcodeClose, true, nil),
+			wantCode: websocket.StatusNormalClosure,
 		},
 		"one byte payload is illegal": {
-			frame: &websocket.Frame{
-				Opcode:  websocket.OpcodeClose,
-				Fin:     true,
-				Payload: []byte("X"),
-			},
+			frame:      websocket.NewFrame(websocket.OpcodeClose, true, []byte("X")),
 			wantCode:   websocket.StatusProtocolError,
 			wantReason: websocket.ErrClosePayloadInvalid.Error(),
 		},
@@ -824,11 +698,7 @@ func TestNetworkErrors(t *testing.T) {
 		//
 		// The _second_ write, writing the close frame before closing the
 		// underlying conn, should succceed.
-		mustWriteFrame(t, conn, true, &websocket.Frame{
-			Opcode:  websocket.OpcodeText,
-			Fin:     true,
-			Payload: []byte("hello"),
-		})
+		mustWriteFrame(t, conn, true, websocket.NewFrame(websocket.OpcodeText, true, []byte("hello")))
 		mustReadCloseFrame(t, conn, websocket.StatusServerError, writeErr)
 	})
 }
@@ -851,21 +721,13 @@ func TestServeLoop(t *testing.T) {
 		}))
 
 		mustWriteFrames(t, conn, true, []*websocket.Frame{
-			{
-				Opcode:  websocket.OpcodeText,
-				Fin:     true,
-				Payload: []byte("ok"),
-			},
-			{
-				Opcode:  websocket.OpcodeText,
-				Fin:     true,
-				Payload: []byte("fail"),
-			},
+			websocket.NewFrame(websocket.OpcodeText, true, []byte("ok")),
+			websocket.NewFrame(websocket.OpcodeText, true, []byte("fail")),
 		})
 
 		// first frame should be echoed as expected
 		frame := mustReadFrame(t, conn, 128)
-		assert.DeepEqual(t, frame.Payload, []byte("ok"), "incorrect payload")
+		assert.DeepEqual(t, frame.Payload(), []byte("ok"), "incorrect payload")
 
 		// second frame should cause the websocket.Handler used by the server
 		// to return an error, which should cause the server to close the
@@ -894,7 +756,7 @@ func TestNew(t *testing.T) {
 
 func mustReadFrame(t testing.TB, src io.Reader, maxPayloadLen int) *websocket.Frame {
 	t.Helper()
-	frame, err := websocket.ReadFrame(src, maxPayloadLen)
+	frame, err := websocket.ReadFrame(src, websocket.ClientMode, maxPayloadLen)
 	assert.NilError(t, err)
 	return frame
 }
@@ -935,16 +797,17 @@ func mustReadCloseFrame(t *testing.T, r io.Reader, wantCode websocket.StatusCode
 	// This is already enforced in validateFrame, called by ReadFrame, but we
 	// must pass in a max payload size here.
 	frame := mustReadFrame(t, r, 125)
-	assert.Equal(t, frame.Opcode, websocket.OpcodeClose, "opcode")
+	t.Logf("XXX FRAME: %v", frame)
+	assert.Equal(t, frame.Opcode(), websocket.OpcodeClose, "opcode")
 
 	// nothing else to validate
 	if wantCode == 0 {
 		return
 	}
 
-	assert.Equal(t, len(frame.Payload) >= 2, true, "expected close frame payload to be at least 2 bytes, got %v", frame.Payload)
-	gotCode := websocket.StatusCode(binary.BigEndian.Uint16(frame.Payload[:2]))
-	gotReason := string(frame.Payload[2:])
+	assert.Equal(t, len(frame.Payload()) >= 2, true, "expected close frame payload to be at least 2 bytes, got %v", frame.Payload())
+	gotCode := websocket.StatusCode(binary.BigEndian.Uint16(frame.Payload()[:2]))
+	gotReason := string(frame.Payload()[2:])
 	t.Logf("got close frame: code=%v msg=%q", gotCode, gotReason)
 	assert.Equal(t, int(gotCode), int(wantCode), "incorrect close status code")
 	if wantErr != nil {


### PR DESCRIPTION
With this experimental refactor, a decoded websocket frame is represented in memory as a single header byte and a payload byte slice.

The single header byte gives us all the info we need at the application level (opcode, fin bit, RSV bits).

Because we unmask the payload at read time and already require callers to specify a mask when writing a frame, we do not need to store the masked bit or the mask key in the frame itself. (This does, however, require passing a mode into ReadFrame so that we can still reject unmasked client frames.)

Because correctly constructing the header byte for a frame is tricky, a new `NewFrame` constructor is now the only way to create a frame.