### PR TITLE
refactor: consolidated error/status code handling

### DIFF
--- a/examples/benchserver/go.mod
+++ b/examples/benchserver/go.mod
@@ -4,6 +4,6 @@ go 1.23.0
 
 require github.com/mccutchen/websocket v0.0.0-20241210041637-21761d5ff7cf
 
-require github.com/goccy/go-json v0.10.4 // indirect
+require github.com/goccy/go-json v0.10.4
 
 replace github.com/mccutchen/websocket => ../../


### PR DESCRIPTION
Here we provide a standardized way to map errors to close codes, and take a naming pass through our errors and codes to better align them with the [IANA's registry of WebSocket Close Codes](https://www.iana.org/assignments/websocket/websocket.xhtml#close-code-number).