### PR TITLE
fix(ci): correct commits in published autobahn reports

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,8 @@ permissions:
   contents: read
 
 env:
-  REPORT_DIR: "out/autobahn"
+  OUT_DIR:    "out"
+  REPORT_DIR: "out/autobahn" # ideally this would reference $OUT_DIR but GH Actions doesn't support that
 
 jobs:
   test:
@@ -97,7 +98,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: autobahn-report
-        path: latest-report
+        path: "${{ env.OUT_DIR }}/latest-report"
 
     - name: build github pages
       run: ./ci/build-github-pages
@@ -105,7 +106,7 @@ jobs:
     - name: upload github pages artifact
       uses: actions/upload-pages-artifact@v3
       with:
-        path: reports
+        path: "${{ env.OUT_DIR }}/reports"
 
     - name: deploy github pages
       id: deployment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
 
     - name: upload autobahn report artifact
       uses: actions/upload-artifact@v4
-      if: github.ref == 'refs/heads/main'
+      # if: github.ref == 'refs/heads/main'
       with:
         name: autobahn-report
         path: ${{ env.REPORT_DIR }}/report
@@ -75,7 +75,7 @@ jobs:
   publish-github-pages:
     runs-on: ubuntu-latest
     needs: autobahn
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
 
     # Set permissions needed for GitHub Pages deployment
     permissions:

--- a/ci/build-github-pages
+++ b/ci/build-github-pages
@@ -29,7 +29,8 @@ COMMIT_TIMESTAMP=$(git show -s --format=%cd --date=format:'%Y%m%d-%H%M%S' "$COMM
 COMMIT_SHA_SHORT=${COMMIT_SHA::8}
 
 KEEP_REPORTS=10
-REPORTS_ROOT="reports"
+OUT_DIR="${OUT_DIR:-out}"
+REPORTS_ROOT="${OUT_DIR}/reports"
 REPORT_DIR="${REPORTS_ROOT}/${COMMIT_TIMESTAMP}-${COMMIT_SHA_SHORT}"
 INDEX_PATH="${REPORTS_ROOT}/index.html"
 
@@ -43,10 +44,10 @@ rm -f "${REPORTS_ROOT}"/robots.txt "${REPORTS_ROOT}"/*.html.*
 
 # Copy new report downloaded from test artifcats to its location in the reports
 # site.
-cp -r latest-report "$REPORT_DIR"
+cp -r "${OUT_DIR}/latest-report" "$REPORT_DIR"
 
 # Generate index.html with $KEEP_REPORTS most recent reports
-cat > ${INDEX_PATH} <<EOF
+cat > "${INDEX_PATH}" <<EOF
 <!DOCTYPE html>
 <html>
 
@@ -117,7 +118,7 @@ for dir in "${REPORT_DIRS[@]}"; do
     # Format the timestamp more readably
     FORMATTED_DATE=$(date -d "${DIR_TIMESTAMP:0:8} ${DIR_TIMESTAMP:9:2}:${DIR_TIMESTAMP:11:2}:${DIR_TIMESTAMP:13:2}" '+%Y-%m-%d %H:%M:%S')
 
-    cat >> ${INDEX_PATH} <<EOF
+    cat >> "${INDEX_PATH}" <<EOF
     <tr>
         <td><a href="${dir_name}/">${FORMATTED_DATE}</a></td>
         <td><a href="https://github.com/mccutchen/websocket/commit/${DIR_SHA}">${DIR_SHA}</a></td>
@@ -126,7 +127,7 @@ EOF
     fi
 done
 
-cat >> ${INDEX_PATH} << 'EOF'
+cat >> "${INDEX_PATH}" << 'EOF'
             </table>
         </section>
     </main>

--- a/ci/build-github-pages
+++ b/ci/build-github-pages
@@ -6,7 +6,7 @@
 # repo, which provides access to the most recent N Autobahn test suite reports.
 #
 # It is meant to be run via our GitHub Actions test workflow, but we can use
-# reasonable defaults for local testing (see GITHUB_SHA and GITHUB_PAGES_URL
+# reasonable defaults for local testing (see COMMIT_SHA and GITHUB_PAGES_URL
 # below.)
 
 set -euo pipefail
@@ -14,16 +14,23 @@ set -x
 
 # We expect our GitHub Actions CI steps to provide these values, but we can
 # offer reasonable defaults for local testing.
-GITHUB_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
+if [ "${GITHUB_EVENT_PATH:-}" != "" ]; then
+    # on pushes to main, we want to take the .after SHA, which is the commit
+    # that will arrive in the main branch. On PRs, during testing, we want to
+    # take the .head SHA.
+    COMMIT_SHA=$(jq -r '.after // .pull_request.head.sha' "$GITHUB_EVENT_PATH")
+else
+    COMMIT_SHA=$(git rev-parse HEAD)
+fi
 GITHUB_PAGES_URL="${GITHUB_PAGES_URL:-https://mccutchen.github.io/websocket/}"
 
 # Figure out timestamp of the newest report
-COMMIT_TIMESTAMP=$(git show -s --format=%cd --date=format:'%Y%m%d-%H%M%S' "$GITHUB_SHA")
-COMMIT_SHA=${GITHUB_SHA::8}
+COMMIT_TIMESTAMP=$(git show -s --format=%cd --date=format:'%Y%m%d-%H%M%S' "$COMMIT_SHA")
+COMMIT_SHA_SHORT=${COMMIT_SHA::8}
 
 KEEP_REPORTS=10
 REPORTS_ROOT="reports"
-REPORT_DIR="${REPORTS_ROOT}/${COMMIT_TIMESTAMP}-${COMMIT_SHA}"
+REPORT_DIR="${REPORTS_ROOT}/${COMMIT_TIMESTAMP}-${COMMIT_SHA_SHORT}"
 INDEX_PATH="${REPORTS_ROOT}/index.html"
 
 mkdir -p "${REPORTS_ROOT}"


### PR DESCRIPTION
Why is it that the most conveniently available commit hash in a github actions workflow _never_ points at what you expect it to?