### PR TITLE
perf: update benchmarks to record throughput

### DIFF
--- a/websocket_test.go
+++ b/websocket_test.go
@@ -985,13 +985,15 @@ func BenchmarkReadFrame(b *testing.B) {
 		// Run sub-benchmarks for each payload size
 		b.Run(formatSize(size), func(b *testing.B) {
 			src := bytes.NewReader(buf.Bytes())
+			b.SetBytes(int64(buf.Len()))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_, _ = src.Seek(0, 0)
-				_, err := websocket.ReadFrame(src, websocket.ServerMode, size)
+				frame2, err := websocket.ReadFrame(src, websocket.ServerMode, size)
 				if err != nil {
 					b.Fatalf("unexpected error: %v", err)
 				}
+				assert.Equal(b, len(frame2.Payload), len(frame.Payload), "payload length")
 			}
 		})
 	}
@@ -1050,6 +1052,7 @@ func BenchmarkReadMessage(b *testing.B) {
 
 		name := fmt.Sprintf("%s/%d", formatSize(msgSize), frameCount)
 		b.Run(name, func(b *testing.B) {
+			b.SetBytes(int64(buf.Len()))
 			for i := 0; i < b.N; i++ {
 				_, _ = reader.Seek(0, 0)
 				msg, err := ws.ReadMessage(context.Background())


### PR DESCRIPTION
Before:

```
BenchmarkReadFrame/1KiB-8                1850740               624.4 ns/op          1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1924210               621.2 ns/op          1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1934340               621.3 ns/op          1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1932159               622.4 ns/op          1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1886798               624.2 ns/op          1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1908315               626.0 ns/op          1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1905510               627.4 ns/op          1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1907787               629.3 ns/op          1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1903112               631.4 ns/op          1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1896978               633.5 ns/op          1064 B/op          5 allocs/op
```

After, note the new `MB/s` column:

```
BenchmarkReadFrame/1KiB-8                1612123               723.2 ns/op      1426.95 MB/s        1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1652838               724.0 ns/op      1425.49 MB/s        1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1653415               731.7 ns/op      1410.46 MB/s        1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1641583               739.1 ns/op      1396.22 MB/s        1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1639408               736.9 ns/op      1400.46 MB/s        1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1633102               735.2 ns/op      1403.63 MB/s        1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1632260               733.5 ns/op      1407.00 MB/s        1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1625856               733.4 ns/op      1407.22 MB/s        1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1631691               735.0 ns/op      1404.14 MB/s        1064 B/op          5 allocs/op
BenchmarkReadFrame/1KiB-8                1615498               742.3 ns/op      1390.33 MB/s        1064 B/op          5 allocs/op
```