### PR TITLE
perf: optimize `ReadFrame`

### DIFF
--- a/proto.go
+++ b/proto.go
@@ -500,6 +500,6 @@ func applyMask(payload []byte, mask MaskingKey) {
 		payload[pos+7] ^= mask[3]
 	}
 	for i := chunks * 8; i < n; i++ {
-		payload[i] ^= mask[i%4]
+		payload[i] ^= mask[i&3] // apparently i&3 faster than i%4
 	}
 }


### PR DESCRIPTION
### Context

Some small — micro? — optimizations suggested by an LLM that hopefully do not harm readability/clarity of code.

### Summary

Each commit represents a separate small optimization, summarized here:
1. **use fixed size arrays where possible to minimize heap allocations** in c13460f
   - ~1.5% improvement over baseline in `sec/op` and `B/op`
   - [benchmark results](https://github.com/mccutchen/websocket/actions/runs/14641143064#summary-41083885049)
2. **convert bytes to lengths directly, skipping `binary.Read()`** in 98daa47
   - Why? [binary.Read()](https://pkg.go.dev/encoding/binary#Read) uses reflection on the destination, copies bytes instead of using them in place, takes an io.Reader interface requiring method dispatch
   - Additional ~0.25% improvement over (1) in `sec/op` and `B/op`
   - [benchmark results](https://github.com/mccutchen/websocket/actions/runs/14641223991#summary-41084157846)
3. **manually optimized payload masking** in a5569e2 
   - Additional ~14% improvement over (2) 🔥
   - [benchmark results](https://github.com/mccutchen/websocket/actions/runs/14649542799#summary-41112026712)
4. **replace modulo division with bit shifting** in 70fcb03
   - Why? TIL that `i % N == i & (N - 1)` when `N` is a power of 2 and bitwise AND is usually a single CPU cycle vs multiple cycles for modulo division
   - Another ~1.5% improvement over (3)
   - [benchmark results](https://github.com/mccutchen/websocket/actions/runs/14650447323#summary-41114911554)

With all of these combined, it appears that we've improved ReadFrame's throughput by ~20%!

### Final results comparing 9efd887 (on `main`) vs 70fcb03

Copied from [workflow summary](https://github.com/mccutchen/websocket/actions/runs/14650447323).

```
goos: linux
goarch: amd64
pkg: github.com/mccutchen/websocket
cpu: AMD EPYC 7763 64-Core Processor                
                       │ ./baseline/bench-results.txt │      ./head/bench-results.txt       │
                       │            sec/op            │   sec/op     vs base                │
ReadFrame/1KiB-4                         1143.0n ± 2%   963.9n ± 3%  -15.67% (p=0.000 n=10)
ReadFrame/1MiB-4                          846.7µ ± 1%   621.5µ ± 0%  -26.60% (p=0.000 n=10)
ReadFrame/8MiB-4                          6.256m ± 0%   4.703m ± 1%  -24.82% (p=0.000 n=10)
ReadFrame/16MiB-4                        12.515m ± 0%   9.474m ± 0%  -24.30% (p=0.000 n=10)
ReadMessage/1KiB/1-4                      1.558µ ± 0%   1.379µ ± 1%  -11.52% (p=0.000 n=10)
ReadMessage/8MiB/1-4                      7.041m ± 0%   5.486m ± 0%  -22.09% (p=0.000 n=10)
ReadMessage/16MiB/1-4                     14.12m ± 0%   11.03m ± 1%  -21.92% (p=0.000 n=10)
ReadMessage/1KiB/4-4                      2.707µ ± 0%   2.436µ ± 0%   -9.99% (p=0.000 n=10)
ReadMessage/8MiB/4-4                     10.534m ± 5%   8.325m ± 4%  -20.97% (p=0.000 n=10)
ReadMessage/16MiB/4-4                     19.22m ± 2%   17.43m ± 8%   -9.36% (p=0.000 n=10)
ReadMessage/1KiB/16-4                     4.965µ ± 0%   4.721µ ± 0%   -4.92% (p=0.000 n=10)
ReadMessage/8MiB/16-4                     16.29m ± 9%   14.02m ± 4%  -13.96% (p=0.000 n=10)
ReadMessage/16MiB/16-4                    22.13m ± 7%   19.50m ± 5%  -11.89% (p=0.000 n=10)
geomean                                   709.4µ        588.5µ       -17.04%

                       │ ./baseline/bench-results.txt │       ./head/bench-results.txt        │
                       │             B/s              │      B/s       vs base                │
ReadFrame/1KiB-4                         860.9Mi ± 2%   1021.0Mi ± 3%  +18.61% (p=0.000 n=10)
ReadFrame/1MiB-4                         1.153Gi ± 1%    1.571Gi ± 0%  +36.24% (p=0.000 n=10)
ReadFrame/8MiB-4                         1.249Gi ± 0%    1.661Gi ± 1%  +33.02% (p=0.000 n=10)
ReadFrame/16MiB-4                        1.249Gi ± 0%    1.649Gi ± 0%  +32.10% (p=0.000 n=10)
ReadMessage/1KiB/1-4                     631.5Mi ± 0%    713.5Mi ± 1%  +12.99% (p=0.000 n=10)
ReadMessage/8MiB/1-4                     1.110Gi ± 0%    1.424Gi ± 0%  +28.35% (p=0.000 n=10)
ReadMessage/16MiB/1-4                    1.107Gi ± 0%    1.417Gi ± 1%  +28.07% (p=0.000 n=10)
ReadMessage/1KiB/4-4                     372.1Mi ± 0%    413.4Mi ± 0%  +11.09% (p=0.000 n=10)
ReadMessage/8MiB/4-4                     759.4Mi ± 5%    961.0Mi ± 4%  +26.53% (p=0.000 n=10)
ReadMessage/16MiB/4-4                    832.3Mi ± 2%    918.3Mi ± 8%  +10.34% (p=0.000 n=10)
ReadMessage/1KiB/16-4                    215.1Mi ± 0%    226.3Mi ± 0%   +5.17% (p=0.000 n=10)
ReadMessage/8MiB/16-4                    491.2Mi ± 8%    570.8Mi ± 4%  +16.22% (p=0.000 n=10)
ReadMessage/16MiB/16-4                   723.0Mi ± 6%    820.6Mi ± 5%  +13.50% (p=0.000 n=10)
geomean                                  751.3Mi         905.6Mi       +20.54%

                       │ ./baseline/bench-results.txt │       ./head/bench-results.txt        │
                       │             B/op             │     B/op      vs base                 │
ReadFrame/1KiB-4                         1.039Ki ± 0%   1.039Ki ± 0%       ~ (p=1.000 n=10) ¹
ReadFrame/1MiB-4                         1.000Mi ± 0%   1.000Mi ± 0%       ~ (p=0.071 n=10)
ReadFrame/8MiB-4                         8.000Mi ± 0%   8.000Mi ± 0%       ~ (p=0.809 n=10)
ReadFrame/16MiB-4                        16.00Mi ± 0%   16.00Mi ± 0%  +0.00% (p=0.040 n=10)
ReadMessage/1KiB/1-4                     1.070Ki ± 0%   1.070Ki ± 0%       ~ (p=1.000 n=10) ¹
ReadMessage/8MiB/1-4                     8.000Mi ± 0%   8.000Mi ± 0%       ~ (p=0.666 n=10)
ReadMessage/16MiB/1-4                    16.00Mi ± 0%   16.00Mi ± 0%       ~ (p=0.862 n=10)
ReadMessage/1KiB/4-4                     3.938Ki ± 0%   3.938Ki ± 0%       ~ (p=1.000 n=10) ¹
ReadMessage/8MiB/4-4                     28.57Mi ± 0%   28.57Mi ± 0%       ~ (p=0.444 n=10)
ReadMessage/16MiB/4-4                    57.09Mi ± 0%   57.09Mi ± 0%       ~ (p=0.873 n=10)
ReadMessage/1KiB/16-4                    4.781Ki ± 0%   4.781Ki ± 0%       ~ (p=1.000 n=10) ¹
ReadMessage/8MiB/16-4                    47.22Mi ± 0%   47.22Mi ± 0%       ~ (p=0.724 n=10)
ReadMessage/16MiB/16-4                   93.81Mi ± 0%   93.81Mi ± 0%  +0.00% (p=0.007 n=10)
geomean                                  1.065Mi        1.065Mi       -0.00%
¹ all samples are equal

                       │ ./baseline/bench-results.txt │      ./head/bench-results.txt       │
                       │          allocs/op           │ allocs/op   vs base                 │
ReadFrame/1KiB-4                           5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
ReadFrame/1MiB-4                           5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
ReadFrame/8MiB-4                           5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
ReadFrame/16MiB-4                          5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
ReadMessage/1KiB/1-4                       6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=10) ¹
ReadMessage/8MiB/1-4                       7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=10) ¹
ReadMessage/16MiB/1-4                      7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=10) ¹
ReadMessage/1KiB/4-4                       24.00 ± 0%   24.00 ± 0%       ~ (p=1.000 n=10) ¹
ReadMessage/8MiB/4-4                       26.00 ± 0%   26.00 ± 0%       ~ (p=1.000 n=10) ¹
ReadMessage/16MiB/4-4                      26.00 ± 0%   26.00 ± 0%       ~ (p=1.000 n=10) ¹
ReadMessage/1KiB/16-4                      70.00 ± 0%   70.00 ± 0%       ~ (p=1.000 n=10) ¹
ReadMessage/8MiB/16-4                      95.00 ± 1%   95.00 ± 1%       ~ (p=1.000 n=10)
ReadMessage/16MiB/16-4                     94.00 ± 0%   94.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                    14.95        14.95       +0.00%
¹ all samples are equal
```

_Note: All intermediate results are combined into the edit history of https://github.com/mccutchen/websocket/pull/50#issuecomment-2827387222, which shows only the latest results._