### PR TITLE
perf: eliminate bounds checks in applyMask

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mccutchen/websocket
 
-go 1.21.0
+go 1.22.0

--- a/proto.go
+++ b/proto.go
@@ -488,18 +488,21 @@ func NewMaskingKey() MaskingKey {
 func applyMask(payload []byte, mask MaskingKey) {
 	n := len(payload)
 	chunks := n / 8
-	for i := 0; i < chunks; i++ {
-		pos := i * 8
-		payload[pos+0] ^= mask[0]
-		payload[pos+1] ^= mask[1]
-		payload[pos+2] ^= mask[2]
-		payload[pos+3] ^= mask[3]
-		payload[pos+4] ^= mask[0]
-		payload[pos+5] ^= mask[1]
-		payload[pos+6] ^= mask[2]
-		payload[pos+7] ^= mask[3]
+	for i := range chunks {
+		// create a slice of exactly 8 bytes that the compiler can verify and
+		// eliminate bounds checks on the 8 xor operations per iteration
+		chunk := payload[i*8 : i*8+8]
+		chunk[0] ^= mask[0]
+		chunk[1] ^= mask[1]
+		chunk[2] ^= mask[2]
+		chunk[3] ^= mask[3]
+		chunk[4] ^= mask[0]
+		chunk[5] ^= mask[1]
+		chunk[6] ^= mask[2]
+		chunk[7] ^= mask[3]
 	}
-	for i := chunks * 8; i < n; i++ {
-		payload[i] ^= mask[i&3] // apparently i&3 faster than i%4
+	remainder := payload[chunks*8:]
+	for i := range len(remainder) {
+		remainder[i] ^= mask[i&3] // i&3 == i%4, but faster
 	}
 }


### PR DESCRIPTION
### Context

A small follow-up to #50, inspired by this blog post that walks through optimizing away bounds checks (as well as enabling inlining).

Note, there are still two bounds checks per `applyMask()`, on [line 494](https://github.com/mccutchen/websocket/blob/c1682783f80314a10ab51bb7f899a5178a5630ef/proto.go#L494) and [line 504](https://github.com/mccutchen/websocket/blob/c1682783f80314a10ab51bb7f899a5178a5630ef/proto.go#L504):

```
$ go build -gcflags '-d=ssa/check_bce/debug=1'
# github.com/mccutchen/websocket
./proto.go:322:28: Found IsInBounds
./proto.go:368:60: Found IsSliceInBounds
./proto.go:439:49: Found IsSliceInBounds
./proto.go:494:19: Found IsSliceInBounds
./proto.go:504:22: Found IsSliceInBounds
```

But that's an improvement on the 9 bounds checks we were seeing previously:

```
$ go build -gcflags '-d=ssa/check_bce/debug=1'
# github.com/mccutchen/websocket
./proto.go:322:28: Found IsInBounds
./proto.go:368:60: Found IsSliceInBounds
./proto.go:439:49: Found IsSliceInBounds
./proto.go:493:10: Found IsInBounds
./proto.go:494:10: Found IsInBounds
./proto.go:495:10: Found IsInBounds
./proto.go:496:10: Found IsInBounds
./proto.go:497:10: Found IsInBounds
./proto.go:498:10: Found IsInBounds
./proto.go:499:10: Found IsInBounds
./proto.go:500:10: Found IsInBounds
./proto.go:503:10: Found IsInBounds
```

### Results

A nice little ~4.5% improvement to throughput according to [the results posted below](https://github.com/mccutchen/websocket/pull/53#issuecomment-2843504341):

```
                  │ ./baseline/bench-results.txt │      ./head/bench-results.txt       │
                  │            sec/op            │   sec/op     vs base                │
ReadFrame/1KiB-4                     982.4n ± 1%   906.8n ± 2%   -7.71% (p=0.000 n=10)
ReadFrame/1MiB-4                     628.9µ ± 0%   561.0µ ± 1%  -10.79% (p=0.000 n=10)
WriteFrame/1KiB-4                    1.341µ ± 0%   1.360µ ± 1%   +1.42% (p=0.000 n=10)
WriteFrame/1MiB-4                    1.039m ± 1%   1.035m ± 1%        ~ (p=0.105 n=10)
geomean                              30.46µ        29.08µ        -4.51%

                  │ ./baseline/bench-results.txt │       ./head/bench-results.txt        │
                  │             B/s              │      B/s       vs base                │
ReadFrame/1KiB-4                   1002.8Mi ± 1%   1086.4Mi ± 2%   +8.35% (p=0.000 n=10)
ReadFrame/1MiB-4                    1.553Gi ± 0%    1.741Gi ± 1%  +12.10% (p=0.000 n=10)
WriteFrame/1KiB-4                   735.1Mi ± 0%    724.5Mi ± 1%   -1.44% (p=0.000 n=10)
WriteFrame/1MiB-4                   962.5Mi ± 1%    966.6Mi ± 1%        ~ (p=0.105 n=10)
geomean                             1.006Gi         1.054Gi        +4.71%
```