### PR TITLE
perf: optimize `MarshalFrame`

### DIFF
--- a/proto.go
+++ b/proto.go
@@ -304,16 +304,16 @@ func MarshalFrame(frame *Frame, mask MaskingKey) []byte {
 		payloadOffset = 2 // at least 2 bytes will be taken by header
 	)
 
-	// pre-allocate buffer into which the frame will be serialized before
-	// writing to dst, where a) we know we will always write to at least the
-	// first two bytes and b) we pick the worst case header size, which might
-	// waste up to 12 bytes for small, unmasked frames
+	// Pre-allocate buffer into which frame will be marshaled, where a) we know
+	// we will always write to at least the first two bytes and b) we guarnatee
+	// enough space by picking the worst case header size (which might waste up
+	// to 12 bytes for small, unmasked frames)
 	buf := make([]byte, 2, maxFrameMetadataSize+payloadLen)
 
-	// first header byte can be written directly
+	// First header byte can be written directly
 	buf[0] = frame.header
 
-	// second header byte depends on mask and payload size
+	// Second header byte depends on mask and payload size
 	masked := mask != Unmasked
 	if masked {
 		buf[1] |= 0b1000_0000
@@ -336,9 +336,8 @@ func MarshalFrame(frame *Frame, mask MaskingKey) []byte {
 	if masked {
 		buf = append(buf, mask[:]...)
 		payloadOffset += 4
-		payloadEnd := payloadOffset + payloadLen
 		buf = append(buf, frame.Payload...)
-		applyMask(buf[payloadOffset:payloadEnd], mask)
+		applyMask(buf[payloadOffset:payloadOffset+payloadLen], mask)
 	} else {
 		buf = append(buf, frame.Payload...)
 	}

--- a/proto.go
+++ b/proto.go
@@ -324,13 +324,18 @@ func MarshalFrame(frame *Frame, mask MaskingKey) []byte {
 	}
 
 	// Optional masking key and actual payload
+	//
+	// Note that we manually extend capacity of buffer as necessary to enable
+	// use of `copy()` instead of `append()`
 	if masked {
-		buf = append(buf, mask[:]...)
+		buf = buf[:payloadOffset+payloadLen+4]
+		copy(buf[payloadOffset:payloadOffset+4], mask[:])
 		payloadOffset += 4
-		buf = append(buf, frame.Payload...)
+		copy(buf[payloadOffset:payloadOffset+payloadLen], frame.Payload)
 		applyMask(buf[payloadOffset:payloadOffset+payloadLen], mask)
 	} else {
-		buf = append(buf, frame.Payload...)
+		buf = buf[:payloadOffset+payloadLen]
+		copy(buf[payloadOffset:payloadOffset+payloadLen], frame.Payload)
 	}
 	return buf
 }

--- a/proto.go
+++ b/proto.go
@@ -331,7 +331,7 @@ func MarshalFrame(frame *Frame, mask MaskingKey) []byte {
 	if masked {
 		buf = append(buf, mask[:]...)
 		for i, b := range frame.Payload {
-			buf = append(buf, b^mask[i%4])
+			buf = append(buf, b^mask[i&3]) // i&3 == i%4, but faster
 		}
 	} else {
 		buf = append(buf, frame.Payload...)


### PR DESCRIPTION
### Context

Some small optimizations for `MarshalFrame` (and therefore also `WriteFrame`) that hopefully do not harm readability/clarity of code.  See also https://github.com/mccutchen/websocket/pull/50 for `ReadFrame` optimizations, from which the we learned some of the tricks below.

### Summary

> [!NOTE]
> 👉 With all of these combined, it appears that **we've improved `WriteFrame`'s throughput by ~27%**!

Each commit represents a separate small optimization, summarized here:
1. **small optimization for writing first two bytes to pre-allocated buffer** in 73e023c
   - ~4.5% improvement in throughput (this was a bit surprising to me!)
   - [benchmark results](https://github.com/mccutchen/websocket/actions/runs/14917338284#summary-41905885183)
   - (This also dropped the `marshaledSize()` helper in favor of pre-allocating worst-case buffer size, but that was restored in 00024a3 without meaningful impact on performance)
2. **replace modulo division with bit shifting** in 0bbc064
   - Why? As discovered in https://github.com/mccutchen/websocket/pull/50, `i % N == i & (N - 1)` when `N` is a power of 2 and bitwise AND is usually a single CPU cycle vs multiple cycles for modulo division
   - Additional ~4% improvement over (1)
   - [benchmark results](https://github.com/mccutchen/websocket/actions/runs/14919413428#summary-41911862024)
3. **use manually-optimized `applyMask()` from #50** in 502dcc3
   - Additional ~14% improvement over (2) 🔥
   - [benchmark results](https://github.com/mccutchen/websocket/actions/runs/14921109799#summary-41916569643)
4. **use `copy()` instead of `append()` for writing mask and payload* in b082698
   - Additional ~3.5% improvement over (3)
   - [benchmark results](https://github.com/mccutchen/websocket/actions/runs/14921109799#summary-41916569643)

### Final results comparing 6526127 (on `main`) vs b082698

Copied from [workflow summary](https://github.com/mccutchen/websocket/actions/runs/14929101004#summary-41940717676).

```
goos: linux
goarch: amd64
pkg: github.com/mccutchen/websocket
cpu: AMD EPYC 7763 64-Core Processor                
                  │ ./baseline/bench-results.txt │      ./head/bench-results.txt       │
                  │            sec/op            │   sec/op     vs base                │
ReadFrame/1KiB-4                     911.2n ± 1%   888.6n ± 3%   -2.49% (p=0.009 n=10)
ReadFrame/1MiB-4                     567.4µ ± 1%   542.2µ ± 1%   -4.44% (p=0.000 n=10)
WriteFrame/1KiB-4                   1329.5n ± 0%   944.6n ± 0%  -28.95% (p=0.000 n=10)
WriteFrame/1MiB-4                   1020.1µ ± 0%   584.4µ ± 1%  -42.71% (p=0.000 n=10)
geomean                              28.94µ        22.71µ       -21.52%

                  │ ./baseline/bench-results.txt │       ./head/bench-results.txt        │
                  │             B/s              │      B/s       vs base                │
ReadFrame/1KiB-4                    1.056Gi ± 1%    1.083Gi ± 3%   +2.55% (p=0.009 n=10)
ReadFrame/1MiB-4                    1.721Gi ± 1%    1.801Gi ± 1%   +4.65% (p=0.000 n=10)
WriteFrame/1KiB-4                   740.9Mi ± 0%   1042.9Mi ± 0%  +40.75% (p=0.000 n=10)
WriteFrame/1MiB-4                   980.4Mi ± 0%   1711.1Mi ± 1%  +74.54% (p=0.000 n=10)
geomean                             1.059Gi         1.350Gi       +27.42%

                  │ ./baseline/bench-results.txt │       ./head/bench-results.txt        │
                  │             B/op             │     B/op      vs base                 │
ReadFrame/1KiB-4                    1.164Ki ± 0%   1.164Ki ± 0%       ~ (p=1.000 n=10) ¹
ReadFrame/1MiB-4                    1.008Mi ± 0%   1.008Mi ± 0%  +0.00% (p=0.016 n=10)
WriteFrame/1KiB-4                   1.125Ki ± 0%   1.125Ki ± 0%       ~ (p=1.000 n=10) ¹
WriteFrame/1MiB-4                   1.008Mi ± 0%   1.008Mi ± 0%  -0.00% (p=0.001 n=10)
geomean                             34.37Ki        34.37Ki       -0.00%
¹ all samples are equal

                  │ ./baseline/bench-results.txt │      ./head/bench-results.txt       │
                  │          allocs/op           │ allocs/op   vs base                 │
ReadFrame/1KiB-4                      5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
ReadFrame/1MiB-4                      5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
WriteFrame/1KiB-4                     1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
WriteFrame/1MiB-4                     1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                               2.236        2.236       +0.00%
¹ all samples are equal
```

_Note: All intermediate results are combined into the edit history of https://github.com/mccutchen/websocket/pull/55#issuecomment-2864573139, which shows only the latest results._