### PR TITLE
security: apply best practices to GH Actions workflows

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -18,6 +18,8 @@ concurrency:
   group: "${{ github.workflow }}-${{ inputs.pr_number }}"
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   baseline:
     runs-on: ubuntu-latest
@@ -119,8 +121,6 @@ jobs:
   analysis:
     needs: [baseline, head]
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
 
     steps:
       - name: download baseline results
@@ -169,3 +169,5 @@ jobs:
           header: results
           path: pr_comment
           number: ${{ inputs.pr_number }}
+        permissions:
+          pull-requests: write

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -30,25 +30,30 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: determine baseline commit
         id: get-baseline
+        env:
+          INPUT_BASELINE_SHA: "${{ inputs.baseline_sha }}"
         run: |
-          if [ -z "${{ inputs.baseline_sha }}" ]; then
+          if [ -z "${INPUT_BASELINE_SHA}" ]; then
             git fetch origin main
             BASELINE=$(git rev-parse origin/main)
           else
-            BASELINE="${{ inputs.baseline_sha }}"
+            BASELINE="${INPUT_BASELINE_SHA}"
           fi
           echo "baseline=${BASELINE::7}" >> $GITHUB_OUTPUT
 
       - name: run baseline benchmarks
+        env:
+          BASELINE: "${{ steps.get-baseline.outputs.baseline }}"
         run: |
-          git checkout ${{ steps.get-baseline.outputs.baseline }}
+          git checkout "${BASELINE}"
           make bench | tee bench-results.txt
           cat <<EOF >> $GITHUB_STEP_SUMMARY
-          ### baseline benchmarks (${{ steps.get-baseline.outputs.baseline }})
+          ### baseline benchmarks (${BASELINE})
           \`\`\`
           $(cat bench-results.txt)
           \`\`\`
@@ -73,13 +78,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: get pr head commit
         id: get-head
+        env:
+          PR_NUMBER: "${{ inputs.pr_number }}"
         run: |
           # Use GitHub API to get PR details
           PR_DATA=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ inputs.pr_number }}")
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}")
 
           HEAD_SHA=$(echo "$PR_DATA" | jq -r .head.sha)
           if [ "$HEAD_SHA" = "null" ]; then
@@ -89,11 +97,13 @@ jobs:
           echo "head=${HEAD_SHA::7}" >> $GITHUB_OUTPUT
 
       - name: run head benchmarks
+        env:
+          HEAD: "${{ steps.get-head.outputs.head }}"
         run: |
-          git checkout ${{ steps.get-head.outputs.head }}
+          git checkout ${HEAD}
           make bench | tee bench-results.txt
           cat <<EOF >> $GITHUB_STEP_SUMMARY
-          ### HEAD benchmarks (${{ steps.get-head.outputs.head }})
+          ### HEAD benchmarks (${HEAD})
           \`\`\`
           $(cat bench-results.txt)
           \`\`\`
@@ -131,11 +141,12 @@ jobs:
           go-version: "stable"
 
       - name: compare results with benchstat
+        env:
+          BASELINE: "${{ needs.baseline.outputs.baseline_sha }}"
+          HEAD: "${{ needs.head.outputs.head_sha }}"
         run: |
           set -euo pipefail
 
-          BASELINE="${{ needs.baseline.outputs.baseline_sha }}"
-          HEAD="${{ needs.head.outputs.head_sha }}"
           COMPARE_URL="https://github.com/${{ github.repository }}/compare/$BASELINE...$HEAD"
           COMPARE_LINK="[$BASELINE...$HEAD]($COMPARE_URL)"
           SUMMARY_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -122,6 +122,9 @@ jobs:
     needs: [baseline, head]
     runs-on: ubuntu-latest
 
+    permissions:
+      pull-requests: write
+
     steps:
       - name: download baseline results
         uses: actions/download-artifact@v4
@@ -169,5 +172,3 @@ jobs:
           header: results
           path: pr_comment
           number: ${{ inputs.pr_number }}
-        permissions:
-          pull-requests: write

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main] # on pull requests AGAINST main
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,9 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
+
       - uses: golangci/golangci-lint-action@v6
         with:
           version: latest

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -9,6 +9,10 @@ permissions: {}
 jobs:
   bench-instructions:
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
     steps:
       - name: compose benchmark instructions
         env:
@@ -39,5 +43,3 @@ jobs:
         with:
           header: instructions
           path: pr_comment
-        permissions:
-          pull-requests: write

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: compose benchmark instructions
         env:
-          HEAD_SHA: "${{ github.event.pull_request.number }}"
+          HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -4,8 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   bench-instructions:
@@ -40,3 +39,5 @@ jobs:
         with:
           header: instructions
           path: pr_comment
+        permissions:
+          pull-requests: write

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -12,13 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: compose benchmark instructions
+        env:
+          HEAD_SHA: "${{ github.event.pull_request.number }}"
         run: |
           set -euo pipefail
 
           # Create a URL-encoded dispatch URL that will pre-fill the parameters
           REPO="${{ github.repository }}"
           WORKFLOW_ID="bench"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
           # Create the workflow dispatch URL
           PR_NUMBER="${{ github.event.pull_request.number }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,8 @@ jobs:
 
     - name: checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: test
       run: make testci
@@ -60,6 +62,8 @@ jobs:
 
     - name: checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: run autobahn tests
       run: |
@@ -95,6 +99,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        persist-credentials: false
         fetch-depth: 0  # Full history for commit timestamps
 
     - name: setup pages
@@ -129,6 +134,8 @@ jobs:
 
     - name: checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: build examples
       run: make examples


### PR DESCRIPTION
Following the guidance of [zizmor](https://docs.zizmor.sh), a security-focused linter for GitHub Actions workflows.

With these changes, zizmor now passes on non-pedantic mode:

```
$ zizmor .github/workflows
 INFO audit: zizmor: 🌈 completed .github/workflows/bench.yaml
 INFO audit: zizmor: 🌈 completed .github/workflows/lint.yaml
 INFO audit: zizmor: 🌈 completed .github/workflows/new-pull-request.yaml
 INFO audit: zizmor: 🌈 completed .github/workflows/test.yaml
No findings to report. Good job! (27 suppressed)
```

All of the 27 suppressed findings are about not pinning actions to hashes.  I'll need to tackle that separately.