### PR TITLE
security: pin all github actions

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -26,11 +26,11 @@ jobs:
     outputs:
       baseline_sha: ${{ steps.get-baseline.outputs.baseline }}
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "stable"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -62,7 +62,7 @@ jobs:
           EOF
 
       - name: upload baseline results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: baseline-results
           path: bench-results.txt
@@ -73,11 +73,11 @@ jobs:
     outputs:
       head_sha: ${{ steps.get-head.outputs.head }}
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "stable"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -112,7 +112,7 @@ jobs:
           EOF
 
       - name: upload head results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: head-results
           path: bench-results.txt
@@ -127,19 +127,19 @@ jobs:
 
     steps:
       - name: download baseline results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: baseline-results
           path: ./baseline
 
       - name: download head results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: head-results
           path: ./head
 
       - name: install go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "stable"
 
@@ -167,7 +167,7 @@ jobs:
           cat pr_comment >> $GITHUB_STEP_SUMMARY
 
       - name: post benchmark results
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
         with:
           header: results
           path: pr_comment

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,14 +12,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: 'stable'
 
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: latest

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -39,7 +39,7 @@ jobs:
           EOF
 
       - name: post benchmark instructions
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
         with:
           header: instructions
           path: pr_comment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
     - name: setup
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: ${{matrix.go-version}}
 
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
 
@@ -45,7 +45,7 @@ jobs:
       run: make testci
 
     - name: report code coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
@@ -56,12 +56,12 @@ jobs:
 
     steps:
     - name: setup
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: stable
 
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
 
@@ -75,7 +75,7 @@ jobs:
         find "${OUT_DIR}" -type f -name '*.json' -delete
 
     - name: upload autobahn report artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: github.ref == 'refs/heads/main'
       with:
         name: autobahn-report
@@ -97,16 +97,16 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
         fetch-depth: 0  # Full history for commit timestamps
 
     - name: setup pages
-      uses: actions/configure-pages@v4
+      uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
 
     - name: download latest autobahn report
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: autobahn-report
         path: "${{ env.OUT_DIR }}/latest-report"
@@ -115,25 +115,25 @@ jobs:
       run: ./ci/build-github-pages
 
     - name: upload github pages artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
       with:
         path: "${{ env.OUT_DIR }}/reports"
 
     - name: deploy github pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   examples:
     runs-on: ubuntu-latest
 
     steps:
     - name: setup
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: stable
 
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
 

--- a/autobahn_test.go
+++ b/autobahn_test.go
@@ -123,7 +123,7 @@ func TestAutobahn(t *testing.T) {
 	autobahnCfgFile, err := os.Create(path.Join(testDir, "autobahn.json"))
 	assert.NilError(t, err)
 	assert.NilError(t, json.NewEncoder(autobahnCfgFile).Encode(autobahnCfg))
-	autobahnCfgFile.Close()
+	assert.NilError(t, autobahnCfgFile.Close())
 
 	pullCmd := exec.Command("docker", "pull", autobahnImage)
 	runCmd(t, pullCmd)
@@ -253,7 +253,7 @@ func loadSummary(t *testing.T, testDir string) []autobahnReportResult {
 	t.Helper()
 	f, err := os.Open(path.Join(testDir, "report", "index.json"))
 	assert.NilError(t, err)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	var summary autobahnReportSummary
 	assert.NilError(t, json.NewDecoder(f).Decode(&summary))
 	var results []autobahnReportResult
@@ -312,5 +312,5 @@ func (r autobahnReportResult) Failed() bool {
 	if allowNonStrict[r.ID] {
 		okayBehavior["NON-STRICT"] = true
 	}
-	return !(okayBehavior[r.Behavior] && okayBehavior[r.BehaviorClose])
+	return !okayBehavior[r.Behavior] || !okayBehavior[r.BehaviorClose]
 }

--- a/internal/testing/must/must.go
+++ b/internal/testing/must/must.go
@@ -31,7 +31,9 @@ func ReadAll(t testing.TB, r io.Reader) string {
 		t.Fatalf("error reading: %s", err)
 	}
 	if rc, ok := r.(io.ReadCloser); ok {
-		rc.Close()
+		if err := rc.Close(); err != nil {
+			t.Fatalf("error closing after reading: %s", err)
+		}
 	}
 	return string(body)
 }

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -851,7 +851,7 @@ func setupRawConnWithHandler(t testing.TB, handler http.Handler) net.Conn {
 	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
 	assert.NilError(t, err)
 	t.Cleanup(func() {
-		assert.NilError(t, conn.Close())
+		_ = conn.Close()
 		srv.Close()
 	})
 

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -270,7 +270,7 @@ func TestConnectionLimits(t *testing.T) {
 
 		// close client connection, which should interrupt the server's
 		// blocking read call on the connection
-		conn.Close()
+		assert.NilError(t, conn.Close())
 		assertConnClosed(t, conn)
 
 		assert.Equal(t, os.IsTimeout(clientReadErr), true, "expected timeout error")
@@ -851,7 +851,7 @@ func setupRawConnWithHandler(t testing.TB, handler http.Handler) net.Conn {
 	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
 	assert.NilError(t, err)
 	t.Cleanup(func() {
-		conn.Close()
+		assert.NilError(t, conn.Close())
 		srv.Close()
 	})
 


### PR DESCRIPTION
A fast follow on #56, where I used https://github.com/mheap/pin-github-action to pin all github actions to immutable commit hashes.