### PR TITLE
perf: apply masking key 8 bytes at a time

### DIFF
--- a/proto_test.go
+++ b/proto_test.go
@@ -230,13 +230,12 @@ func BenchmarkWriteFrame(b *testing.B) {
 			assert.NilError(b, websocket.WriteFrame(buf, mask, frame))
 			expectedSize := len(buf.Bytes())
 			b.SetBytes(int64(expectedSize))
-			buf.Reset()
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
 				buf.Reset()
 				assert.NilError(b, websocket.WriteFrame(buf, mask, frame))
-				assert.Equal(b, len(buf.Bytes()), expectedSize, "payload length")
+				assert.Equal(b, buf.Len(), expectedSize, "payload length")
 			}
 		})
 	}


### PR DESCRIPTION
Basically what it says on the tin.  Key results from the benchmarks below, indicating ~35% faster read/write frame and and ~55% higher throughput:

```
                  │ ./baseline/bench-results.txt │       ./head/bench-results.txt       │
                  │            sec/op            │    sec/op     vs base                │
ReadFrame/1KiB-4                     867.5n ± 3%   575.8n ±  4%  -33.63% (p=0.000 n=10)
ReadFrame/1MiB-4                     550.2µ ± 1%   331.0µ ± 18%  -39.84% (p=0.000 n=10)
WriteFrame/1KiB-4                    932.5n ± 0%   675.9n ±  0%  -27.51% (p=0.000 n=10)
WriteFrame/1MiB-4                    588.4µ ± 4%   336.3µ ±  4%  -42.84% (p=0.000 n=10)
geomean                              22.62µ        14.43µ        -36.22%

                  │ ./baseline/bench-results.txt │       ./head/bench-results.txt        │
                  │             B/s              │      B/s       vs base                │
ReadFrame/1KiB-4                    1.109Gi ± 3%   1.671Gi ±  4%  +50.67% (p=0.000 n=10)
ReadFrame/1MiB-4                    1.775Gi ± 1%   2.950Gi ± 15%  +66.22% (p=0.000 n=10)
WriteFrame/1KiB-4                   1.032Gi ± 0%   1.423Gi ±  0%  +37.95% (p=0.000 n=10)
WriteFrame/1MiB-4                   1.660Gi ± 3%   2.904Gi ±  3%  +74.97% (p=0.000 n=10)
geomean                             1.355Gi        2.125Gi        +56.80%
```