### PR TITLE
perf: use internal buffer pool when marshaling frames

### DIFF
--- a/proto.go
+++ b/proto.go
@@ -303,15 +303,16 @@ var writeBufferSizes = [...]int{
 }
 
 var writeBufferPools = [...]sync.Pool{
-	{New: func() any { return make([]byte, 1024) }},
-	{New: func() any { return make([]byte, 4096) }},
-	{New: func() any { return make([]byte, 8192) }},
+	{New: func() any { buf := make([]byte, 1024); return &buf }},
+	{New: func() any { buf := make([]byte, 4096); return &buf }},
+	{New: func() any { buf := make([]byte, 8192); return &buf }},
 }
 
 func getWriteBuffer(size int) []byte {
 	for i, n := range writeBufferSizes {
 		if n >= size {
-			buf := writeBufferPools[i].Get().([]byte)
+			ptr := writeBufferPools[i].Get().(*[]byte)
+			buf := *ptr
 			return buf[:size]
 		}
 	}
@@ -322,7 +323,7 @@ func putWriteBuffer(buf []byte) {
 	bufCap := cap(buf)
 	for i, n := range writeBufferSizes {
 		if n == bufCap {
-			writeBufferPools[i].Put(buf)
+			writeBufferPools[i].Put(&buf)
 			return
 		}
 	}

--- a/proto_test.go
+++ b/proto_test.go
@@ -48,8 +48,10 @@ func TestRSV(t *testing.T) {
 	// We don't currently support any extensions, so RSV bits are not allowed.
 	// But we still need to be able properly parse and marshal them.
 	marshalledFrame := func(rsvBits ...websocket.RSVBit) []byte {
+		buf := &bytes.Buffer{}
 		frame := websocket.NewFrame(websocket.OpcodeText, true, nil, rsvBits...)
-		return websocket.MarshalFrame(frame, websocket.Unmasked)
+		assert.NilError(t, websocket.WriteFrame(buf, websocket.Unmasked, frame))
+		return buf.Bytes()
 	}
 
 	testCases := map[string]struct {

--- a/websocket_internal_test.go
+++ b/websocket_internal_test.go
@@ -44,3 +44,22 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, ws.hooks.OnWriteFrame != nil, true, "OnWriteFrame hook is nil")
 	assert.Equal(t, ws.hooks.OnWriteMessage != nil, true, "OnWriteMessage hook is nil")
 }
+
+func TestWriteBufferPoolConfig(t *testing.T) {
+	t.Parallel()
+
+	// Ensure our manual writeBufferPoolSizes and writeBufferPools arrays are
+	// kept in sync
+	assert.Equal(t, len(writeBufferSizes), len(writeBufferPools),
+		"writeBufferSizes and writeBufferPools arrays must have the same length")
+
+	for i, expectedSize := range writeBufferSizes {
+		buf := writeBufferPools[i].Get().([]byte)
+		assert.Equal(t, len(buf), expectedSize,
+			"pool at index %d should create buffers of size %d, got %d", i, expectedSize, len(buf))
+		assert.Equal(t, cap(buf), expectedSize,
+			"pool at index %d should create buffers with capacity %d, got %d", i, expectedSize, cap(buf))
+		// Put it back to avoid affecting other tests
+		writeBufferPools[i].Put(buf)
+	}
+}

--- a/websocket_internal_test.go
+++ b/websocket_internal_test.go
@@ -44,22 +44,3 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, ws.hooks.OnWriteFrame != nil, true, "OnWriteFrame hook is nil")
 	assert.Equal(t, ws.hooks.OnWriteMessage != nil, true, "OnWriteMessage hook is nil")
 }
-
-func TestWriteBufferPoolConfig(t *testing.T) {
-	t.Parallel()
-
-	// Ensure our manual writeBufferPoolSizes and writeBufferPools arrays are
-	// kept in sync
-	assert.Equal(t, len(writeBufferSizes), len(writeBufferPools),
-		"writeBufferSizes and writeBufferPools arrays must have the same length")
-
-	for i, expectedSize := range writeBufferSizes {
-		buf := writeBufferPools[i].Get().([]byte)
-		assert.Equal(t, len(buf), expectedSize,
-			"pool at index %d should create buffers of size %d, got %d", i, expectedSize, len(buf))
-		assert.Equal(t, cap(buf), expectedSize,
-			"pool at index %d should create buffers with capacity %d, got %d", i, expectedSize, cap(buf))
-		// Put it back to avoid affecting other tests
-		writeBufferPools[i].Put(buf)
-	}
-}

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -309,15 +309,19 @@ func TestProtocolOkay(t *testing.T) {
 		conn := setupRawConn(t, newOpts(t))
 		clientFrame := websocket.NewFrame(websocket.OpcodeText, true, []byte("hello"))
 		mustWriteFrame(t, conn, true, clientFrame)
+		t.Logf("wrote initial frame")
 
 		// read server frame and ensure that it matches client frame
 		serverFrame := mustReadFrame(t, conn, maxFrameSize)
 		assert.DeepEqual(t, serverFrame, clientFrame, "matching frames")
+		t.Logf("read server response")
 
 		// ensure closing handshake is completed when initiated by client
 		clientClose := websocket.NewCloseFrame(websocket.StatusNormalClosure, "")
 		mustWriteFrame(t, conn, true, clientClose)
+		t.Logf("wrote close frame")
 		mustReadCloseFrame(t, conn, websocket.StatusNormalClosure, nil)
+		t.Logf("read close frame")
 		assertConnClosed(t, conn)
 	})
 


### PR DESCRIPTION
Optimize writes of small (<= 8KiB) payloads by using a set of internal `[]byte` buffer pools in `WriteFrame` to minimize allocations.