### PR TITLE
chore: bump minimum go version to 1.24 and modernize

### DIFF
--- a/autobahn_test.go
+++ b/autobahn_test.go
@@ -36,6 +36,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -155,7 +156,6 @@ func TestAutobahn(t *testing.T) {
 	}
 
 	for _, result := range summary {
-		result := result
 		t.Run("autobahn/"+result.ID, func(t *testing.T) {
 			if result.Failed() {
 				report := loadReport(t, testDir, result.ReportFile)
@@ -214,17 +214,12 @@ func newAutobahnTargetURL(t *testing.T, targetURL string) string {
 
 func isLocalhost(ipAddr string) bool {
 	ipAddr = strings.ToLower(ipAddr)
-	for _, addr := range []string{
+	return slices.Contains([]string{
 		"localhost",
 		"127.0.0.1",
 		"::1",
 		"0:0:0:0:0:0:0:1",
-	} {
-		if ipAddr == addr {
-			return true
-		}
-	}
-	return false
+	}, ipAddr)
 }
 
 func runCmd(t *testing.T, cmd *exec.Cmd) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mccutchen/websocket
 
-go 1.22.0
+go 1.24.0

--- a/proto_test.go
+++ b/proto_test.go
@@ -81,7 +81,6 @@ func TestRSV(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			buf := bytes.NewReader(tc.rawBytes)
@@ -143,7 +142,6 @@ func TestExampleFramesFromRFC(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			buf := bytes.NewReader(tc.rawBytes)
@@ -177,7 +175,6 @@ func TestIncompleteFrames(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			buf := bytes.NewReader(tc.rawBytes)
@@ -207,7 +204,7 @@ func BenchmarkReadFrame(b *testing.B) {
 			src := bytes.NewReader(buf.Bytes())
 			b.SetBytes(int64(buf.Len()))
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_, _ = src.Seek(0, 0)
 				frame2, err := websocket.ReadFrame(src, websocket.ServerMode, size)
 				if err != nil {
@@ -232,7 +229,7 @@ func BenchmarkWriteFrame(b *testing.B) {
 			b.SetBytes(int64(expectedSize))
 			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				buf.Reset()
 				assert.NilError(b, websocket.WriteFrame(buf, mask, frame))
 				assert.Equal(b, buf.Len(), expectedSize, "payload length")

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -117,7 +117,6 @@ func TestHandshake(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -563,7 +562,6 @@ func TestProtocolErrors(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
-		tc := tc
 		if tc.opts == nil {
 			tc.opts = newOpts
 		}
@@ -629,7 +627,6 @@ func TestCloseFrames(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			conn := setupRawConn(t, websocket.Options{})
 			t.Logf("sending close frame %v", tc.frame)


### PR DESCRIPTION
The results of running

    go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...

See [modernize analyzer docs][1] for more info.

[1]: https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize